### PR TITLE
ObjectType Extends Custom Primitives

### DIFF
--- a/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
@@ -43,10 +43,13 @@ Array [
     "type": "object",
   },
   Object {
-    "additionalProperties": Object {
-      "type": "unknown",
-    },
+    "additionalProperties": false,
     "description": "An asset that contains a Binding.",
+    "extends": Object {
+      "genericArguments": undefined,
+      "ref": "Asset",
+      "type": "ref",
+    },
     "genericTokens": undefined,
     "name": "AssetBinding",
     "properties": Object {
@@ -56,23 +59,6 @@ Array [
           "genericArguments": undefined,
           "ref": "Binding",
           "title": "AssetBinding.binding",
-          "type": "ref",
-        },
-        "required": true,
-      },
-      "id": Object {
-        "node": Object {
-          "description": "Each asset requires a unique id per view",
-          "title": "Asset.id",
-          "type": "string",
-        },
-        "required": true,
-      },
-      "type": Object {
-        "node": Object {
-          "description": "The asset type determines the semantics of how a user interacts with a page",
-          "ref": "T",
-          "title": "Asset.type",
           "type": "ref",
         },
         "required": true,

--- a/xlr/sdk/src/validator.ts
+++ b/xlr/sdk/src/validator.ts
@@ -369,10 +369,12 @@ export class XLRValidator {
     operand: ObjectType,
     errorOnOverlap = true
   ): ObjectType {
+    const baseObjectName = base.name ?? 'object literal';
+    const operandObjectName = operand.name ?? 'object literal';
     const newObject = {
       ...base,
-      name: `${base.name} & ${operand.name}`,
-      description: `Effective type combining ${base.name} and ${operand.name}`,
+      name: `${baseObjectName} & ${operandObjectName}`,
+      description: `Effective type combining ${baseObjectName} and ${operandObjectName}`,
     };
 
     // eslint-disable-next-line no-restricted-syntax, guard-for-in
@@ -384,11 +386,7 @@ export class XLRValidator {
         errorOnOverlap
       ) {
         throw new Error(
-          `Can't compute effective type for ${
-            base.name ?? 'object literal'
-          } and ${
-            operand.name ?? 'object literal'
-          } because of conflicting properties ${property}`
+          `Can't compute effective type for ${baseObjectName} and ${operandObjectName} because of conflicting properties ${property}`
         );
       }
 

--- a/xlr/types/src/core.ts
+++ b/xlr/types/src/core.ts
@@ -100,10 +100,12 @@ export interface ObjectProperty {
   node: NodeType;
 }
 export interface ObjectNode extends TypeNode<'object'> {
-  /** the properties associated with an object */
+  /** The properties associated with an object */
   properties: {
     [name: string]: ObjectProperty;
   };
+  /** A custom primitive that this object extends that is to be resolved when used */
+  extends?: RefType;
   /** What type, if any, of additional properties are allowed on the object */
   additionalProperties: false | NodeType;
 }


### PR DESCRIPTION
Implements #6 and fixes #4 

## Release Notes
ObjectTypes extend custom primitives instead of serializing them. Fixes object literals having the wrong name during some operations when computing union/intersection types. 