### PR TITLE
Recursive Transform Helper

### DIFF
--- a/language/service/src/xlr/__tests__/__snapshots__/transform.test.ts.snap
+++ b/language/service/src/xlr/__tests__/__snapshots__/transform.test.ts.snap
@@ -1,0 +1,362 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Transform Tests AssetWrapperOrSwitch Transform 1`] = `
+Object {
+  "additionalProperties": Object {
+    "type": "unknown",
+  },
+  "description": "Mock Asset for test",
+  "genericTokens": Array [
+    Object {
+      "constraints": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "default": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "symbol": "AnyAsset",
+    },
+  ],
+  "name": "MockAsset",
+  "properties": Object {
+    "id": Object {
+      "node": Object {
+        "description": "Each asset requires a unique id per view",
+        "title": "Asset.id",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "primaryChild": Object {
+      "node": Object {
+        "description": "A text-like asset for the action's label",
+        "genericArguments": Array [
+          Object {
+            "ref": "AnyAsset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapperOrSwitch<AnyAsset>",
+        "title": "ActionAsset.label",
+        "type": "ref",
+      },
+      "required": true,
+    },
+    "secondaryChildren": Object {
+      "node": Object {
+        "elementType": Object {
+          "ref": "Asset",
+          "type": "ref",
+        },
+        "type": "array",
+      },
+      "required": false,
+    },
+    "type": Object {
+      "node": Object {
+        "const": "mock",
+        "description": "The asset type determines the semantics of how a user interacts with a page",
+        "title": "Asset.type",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "value": Object {
+      "node": Object {
+        "description": "The transition value of the action in the state machine",
+        "title": "MockAsset.value",
+        "type": "string",
+      },
+      "required": false,
+    },
+  },
+  "source": "transform.test.ts",
+  "title": "MockAsset",
+  "type": "object",
+}
+`;
+
+exports[`Transform Tests CommonProps Transform 1`] = `
+Object {
+  "additionalProperties": Object {
+    "type": "unknown",
+  },
+  "description": "Mock Asset for test",
+  "genericTokens": Array [
+    Object {
+      "constraints": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "default": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "symbol": "AnyAsset",
+    },
+  ],
+  "name": "MockAsset",
+  "properties": Object {
+    "_comment": Object {
+      "node": Object {
+        "description": "Adds a comment for the given node",
+        "type": "string",
+      },
+      "required": false,
+    },
+    "applicability": Object {
+      "node": Object {
+        "description": "Evaluate the given expression (or boolean) and if falsy, remove this node from the tree. This is re-computed for each change in the data-model",
+        "name": "Applicability",
+        "or": Array [
+          Object {
+            "type": "boolean",
+          },
+          Object {
+            "ref": "Expression",
+            "type": "ref",
+          },
+        ],
+        "type": "or",
+      },
+      "required": false,
+    },
+    "id": Object {
+      "node": Object {
+        "description": "Each asset requires a unique id per view",
+        "title": "Asset.id",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "primaryChild": Object {
+      "node": Object {
+        "description": "A text-like asset for the action's label",
+        "genericArguments": Array [
+          Object {
+            "ref": "AnyAsset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyAsset>",
+        "title": "ActionAsset.label",
+        "type": "ref",
+      },
+      "required": true,
+    },
+    "secondaryChildren": Object {
+      "node": Object {
+        "elementType": Object {
+          "ref": "Asset",
+          "type": "ref",
+        },
+        "type": "array",
+      },
+      "required": false,
+    },
+    "type": Object {
+      "node": Object {
+        "const": "mock",
+        "description": "The asset type determines the semantics of how a user interacts with a page",
+        "title": "Asset.type",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "value": Object {
+      "node": Object {
+        "description": "The transition value of the action in the state machine",
+        "title": "MockAsset.value",
+        "type": "string",
+      },
+      "required": false,
+    },
+  },
+  "source": "transform.test.ts",
+  "title": "MockAsset",
+  "type": "object",
+}
+`;
+
+exports[`Transform Tests applyTemplateProperty Transform 1`] = `
+Object {
+  "additionalProperties": Object {
+    "type": "unknown",
+  },
+  "description": "Mock Asset for test",
+  "genericTokens": Array [
+    Object {
+      "constraints": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "default": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "symbol": "AnyAsset",
+    },
+  ],
+  "name": "MockAsset",
+  "properties": Object {
+    "id": Object {
+      "node": Object {
+        "description": "Each asset requires a unique id per view",
+        "title": "Asset.id",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "primaryChild": Object {
+      "node": Object {
+        "description": "A text-like asset for the action's label",
+        "genericArguments": Array [
+          Object {
+            "ref": "AnyAsset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyAsset>",
+        "title": "ActionAsset.label",
+        "type": "ref",
+      },
+      "required": true,
+    },
+    "secondaryChildren": Object {
+      "node": Object {
+        "elementType": Object {
+          "ref": "Asset",
+          "type": "ref",
+        },
+        "type": "array",
+      },
+      "required": false,
+    },
+    "template": Object {
+      "node": Object {
+        "description": "A list of templates to process for this node",
+        "elementType": Object {
+          "ref": "Template<Asset, \\"secondaryChildren\\">",
+          "type": "ref",
+        },
+        "type": "array",
+      },
+      "required": false,
+    },
+    "type": Object {
+      "node": Object {
+        "const": "mock",
+        "description": "The asset type determines the semantics of how a user interacts with a page",
+        "title": "Asset.type",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "value": Object {
+      "node": Object {
+        "description": "The transition value of the action in the state machine",
+        "title": "MockAsset.value",
+        "type": "string",
+      },
+      "required": false,
+    },
+  },
+  "source": "transform.test.ts",
+  "title": "MockAsset",
+  "type": "object",
+}
+`;
+
+exports[`Transform Tests applyValueRefs Transform 1`] = `
+Object {
+  "additionalProperties": Object {
+    "type": "unknown",
+  },
+  "description": "Mock Asset for test",
+  "genericTokens": Array [
+    Object {
+      "constraints": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "default": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "symbol": "AnyAsset",
+    },
+  ],
+  "name": "MockAsset",
+  "properties": Object {
+    "id": Object {
+      "node": Object {
+        "description": "Each asset requires a unique id per view",
+        "title": "Asset.id",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "primaryChild": Object {
+      "node": Object {
+        "description": "A text-like asset for the action's label",
+        "genericArguments": Array [
+          Object {
+            "ref": "AnyAsset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyAsset>",
+        "title": "ActionAsset.label",
+        "type": "ref",
+      },
+      "required": true,
+    },
+    "secondaryChildren": Object {
+      "node": Object {
+        "elementType": Object {
+          "ref": "Asset",
+          "type": "ref",
+        },
+        "type": "array",
+      },
+      "required": false,
+    },
+    "type": Object {
+      "node": Object {
+        "const": "mock",
+        "description": "The asset type determines the semantics of how a user interacts with a page",
+        "title": "Asset.type",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "value": Object {
+      "node": Object {
+        "description": "The transition value of the action in the state machine",
+        "or": Array [
+          Object {
+            "description": "The transition value of the action in the state machine",
+            "title": "MockAsset.value",
+            "type": "string",
+          },
+          Object {
+            "ref": "ExpressionRef",
+            "type": "ref",
+          },
+          Object {
+            "ref": "BindingRef",
+            "type": "ref",
+          },
+        ],
+        "type": "or",
+      },
+      "required": false,
+    },
+  },
+  "source": "transform.test.ts",
+  "title": "MockAsset",
+  "type": "object",
+}
+`;

--- a/language/service/src/xlr/__tests__/transform.test.ts
+++ b/language/service/src/xlr/__tests__/transform.test.ts
@@ -1,0 +1,111 @@
+import type { NamedTypeWithGenerics, ObjectType } from '@player-tools/xlr';
+import {
+  applyCommonProps,
+  applyAssetWrapperOrSwitch,
+  applyValueRefs,
+  applyTemplateProperty,
+} from '../index';
+
+describe('Transform Tests', () => {
+  let MockAsset: NamedTypeWithGenerics<ObjectType>;
+
+  beforeEach(() => {
+    MockAsset = {
+      name: 'MockAsset',
+      type: 'object',
+      source: 'transform.test.ts',
+      properties: {
+        id: {
+          required: true,
+          node: {
+            type: 'string',
+            title: 'Asset.id',
+            description: 'Each asset requires a unique id per view',
+          },
+        },
+        type: {
+          required: true,
+          node: {
+            type: 'string',
+            const: 'mock',
+            title: 'Asset.type',
+            description:
+              'The asset type determines the semantics of how a user interacts with a page',
+          },
+        },
+        value: {
+          required: false,
+          node: {
+            type: 'string',
+            title: 'MockAsset.value',
+            description:
+              'The transition value of the action in the state machine',
+          },
+        },
+        primaryChild: {
+          required: true,
+          node: {
+            type: 'ref',
+            ref: 'AssetWrapper<AnyAsset>',
+            genericArguments: [
+              {
+                type: 'ref',
+                ref: 'AnyAsset',
+              },
+            ],
+            title: 'ActionAsset.label',
+            description: "A text-like asset for the action's label",
+          },
+        },
+        secondaryChildren: {
+          required: false,
+          node: {
+            type: 'array',
+            elementType: {
+              type: 'ref',
+              ref: 'Asset',
+            },
+          },
+        },
+      },
+      additionalProperties: {
+        type: 'unknown',
+      },
+      title: 'MockAsset',
+      description: 'Mock Asset for test',
+      genericTokens: [
+        {
+          symbol: 'AnyAsset',
+          constraints: {
+            type: 'ref',
+            ref: 'Asset',
+          },
+          default: {
+            type: 'ref',
+            ref: 'Asset',
+          },
+        },
+      ],
+    };
+  });
+
+  it('CommonProps Transform', () => {
+    applyCommonProps(MockAsset, 'Assets');
+    expect(MockAsset).toMatchSnapshot();
+  });
+
+  it('AssetWrapperOrSwitch Transform', () => {
+    applyAssetWrapperOrSwitch(MockAsset, 'Assets');
+    expect(MockAsset).toMatchSnapshot();
+  });
+
+  it('applyValueRefs Transform', () => {
+    applyValueRefs(MockAsset, 'Assets');
+    expect(MockAsset).toMatchSnapshot();
+  });
+
+  it('applyTemplateProperty Transform', () => {
+    applyTemplateProperty(MockAsset, 'Assets');
+    expect(MockAsset).toMatchSnapshot();
+  });
+});

--- a/language/service/src/xlr/transforms.ts
+++ b/language/service/src/xlr/transforms.ts
@@ -9,7 +9,7 @@ import type {
   RefType,
   TransformFunction,
 } from '@player-tools/xlr';
-
+import { simpleTransformGenerator } from '@player-tools/xlr-sdk';
 import { isPrimitiveTypeNode } from '@player-tools/xlr-utils';
 
 /**
@@ -60,37 +60,11 @@ export const applyAssetWrapperOrSwitch: TransformFunction = (
   node: NamedType,
   capability: string
 ) => {
-  if (capability === 'Assets') {
-    if (node.type === 'object') {
-      for (const key in node.properties) {
-        const value = node.properties[key];
-        if (
-          value.node.type === 'ref' &&
-          value.node.ref.includes('AssetWrapper')
-        ) {
-          value.node.ref = value.node.ref.replace(
-            'AssetWrapper',
-            'AssetWrapperOrSwitch'
-          );
-        } else if (value.node.type === 'object') {
-          applyAssetWrapperOrSwitch(
-            value.node as NamedType<ObjectType>,
-            capability
-          );
-        }
-      }
-    } else if (node.type === 'array') {
-      if (
-        node.elementType.type === 'ref' &&
-        node.elementType.ref.includes('AssetWrapper')
-      ) {
-        node.elementType.ref = node.elementType.ref.replace(
-          'AssetWrapper',
-          'AssetWrapperOrSwitch'
-        );
-      }
+  simpleTransformGenerator('ref', 'Assets', (xlrNode) => {
+    if (xlrNode.ref.includes('AssetWrapper')) {
+      xlrNode.ref = xlrNode.ref.replace('AssetWrapper', 'AssetWrapperOrSwitch');
     }
-  }
+  })(node, capability);
 };
 
 /**

--- a/language/service/src/xlr/transforms.ts
+++ b/language/service/src/xlr/transforms.ts
@@ -4,7 +4,7 @@
 import type {
   ArrayType,
   NamedType,
-  ObjectType,
+  NodeType,
   OrType,
   RefType,
   TransformFunction,
@@ -15,44 +15,42 @@ import { isPrimitiveTypeNode } from '@player-tools/xlr-utils';
 /**
  * Adds applicability and _comment properties to Assets
  */
-export const applyCommonProps: TransformFunction = (node, capability) => {
-  simpleTransformGenerator(
-    'object',
-    'Assets',
-    (xlrNode) => {
-      if (!xlrNode.properties.applicability) {
-        xlrNode.properties.applicability = {
-          required: false,
-          node: {
-            type: 'or',
-            name: 'Applicability',
-            description:
-              'Evaluate the given expression (or boolean) and if falsy, remove this node from the tree. This is re-computed for each change in the data-model',
-            or: [
-              {
-                type: 'boolean',
-              },
-              {
-                type: 'ref',
-                ref: 'Expression',
-              },
-            ],
-          },
-        };
-      }
+export const applyCommonProps: TransformFunction = (
+  node: NamedType | NodeType,
+  capability: string
+) => {
+  if (capability === 'Assets') {
+    if (node.type === 'object' && !node.properties.applicability) {
+      node.properties.applicability = {
+        required: false,
+        node: {
+          type: 'or',
+          name: 'Applicability',
+          description:
+            'Evaluate the given expression (or boolean) and if falsy, remove this node from the tree. This is re-computed for each change in the data-model',
+          or: [
+            {
+              type: 'boolean',
+            },
+            {
+              type: 'ref',
+              ref: 'Expression',
+            },
+          ],
+        },
+      };
+    }
+  }
 
-      if (!xlrNode.properties._comment) {
-        xlrNode.properties._comment = {
-          required: false,
-          node: {
-            description: 'Adds a comment for the given node',
-            type: 'string',
-          },
-        };
-      }
-    },
-    false
-  )(node, capability);
+  if (node.type === 'object' && !node.properties._comment) {
+    node.properties._comment = {
+      required: false,
+      node: {
+        description: 'Adds a comment for the given node',
+        type: 'string',
+      },
+    };
+  }
 };
 
 /**

--- a/language/service/src/xlr/transforms.ts
+++ b/language/service/src/xlr/transforms.ts
@@ -13,52 +13,54 @@ import { simpleTransformGenerator } from '@player-tools/xlr-sdk';
 import { isPrimitiveTypeNode } from '@player-tools/xlr-utils';
 
 /**
- *
+ * Adds applicability and _comment properties to Assets
  */
-export const applyCommonProps: TransformFunction = (
-  node: NamedType,
-  capability: string
-) => {
-  if (capability === 'Assets') {
-    if (node.type === 'object' && !node.properties.applicability) {
-      node.properties.applicability = {
-        required: false,
-        node: {
-          type: 'or',
-          name: 'Applicability',
-          description:
-            'Evaluate the given expression (or boolean) and if falsy, remove this node from the tree. This is re-computed for each change in the data-model',
-          or: [
-            {
-              type: 'boolean',
-            },
-            {
-              type: 'ref',
-              ref: 'Expression',
-            },
-          ],
-        },
-      };
-    }
-  }
+export const applyCommonProps: TransformFunction = (node, capability) => {
+  simpleTransformGenerator(
+    'object',
+    'Assets',
+    (xlrNode) => {
+      if (!xlrNode.properties.applicability) {
+        xlrNode.properties.applicability = {
+          required: false,
+          node: {
+            type: 'or',
+            name: 'Applicability',
+            description:
+              'Evaluate the given expression (or boolean) and if falsy, remove this node from the tree. This is re-computed for each change in the data-model',
+            or: [
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'ref',
+                ref: 'Expression',
+              },
+            ],
+          },
+        };
+      }
 
-  if (node.type === 'object' && !node.properties._comment) {
-    node.properties._comment = {
-      required: false,
-      node: {
-        description: 'Adds a comment for the given node',
-        type: 'string',
-      },
-    };
-  }
+      if (!xlrNode.properties._comment) {
+        xlrNode.properties._comment = {
+          required: false,
+          node: {
+            description: 'Adds a comment for the given node',
+            type: 'string',
+          },
+        };
+      }
+    },
+    false
+  )(node, capability);
 };
 
 /**
- *
+ * Replaces AssetWrapper References with AssetWrapperOrSwitch
  */
 export const applyAssetWrapperOrSwitch: TransformFunction = (
-  node: NamedType,
-  capability: string
+  node,
+  capability
 ) => {
   simpleTransformGenerator('ref', 'Assets', (xlrNode) => {
     if (xlrNode.ref.includes('AssetWrapper')) {
@@ -68,19 +70,16 @@ export const applyAssetWrapperOrSwitch: TransformFunction = (
 };
 
 /**
- *
+ * Modifies any primitive type property node (except id/type) to be Bindings or Expressions
  */
-export const applyValueRefs: TransformFunction = (
-  node: NamedType,
-  capability: string
-) => {
-  if (capability === 'Assets' && node.type === 'object') {
-    for (const key in node.properties) {
+export const applyValueRefs: TransformFunction = (node, capability) => {
+  simpleTransformGenerator('object', 'Assets', (xlrNode) => {
+    for (const key in xlrNode.properties) {
       if (key === 'id' || key === 'type') {
         continue;
       }
 
-      const value = node.properties[key];
+      const value = xlrNode.properties[key];
       if (value.node.type === 'or') {
         value.node.or.push({
           type: 'ref',
@@ -107,49 +106,31 @@ export const applyValueRefs: TransformFunction = (
           ],
         };
         value.node = newUnionType;
-      } else if (value.node.type === 'object') {
-        applyValueRefs(value.node as NamedType<ObjectType>, capability);
       }
     }
-  }
+  })(node, capability);
 };
 
 /**
- *
+ * Computes possible template keys and adds them to an Asset
  */
-export const applyTemplateProperty: TransformFunction = (
-  node: NamedType,
-  capability: string
-) => {
-  if (capability === 'Assets' && node.type === 'object') {
-    const templateTypes: Array<RefType> = [];
-
-    /** walks the asset to find arrays that could be possible templates */
-    const assetWalker = (
-      rootNode: NamedType<ObjectType>,
-      collector: Array<RefType>
-    ) => {
-      for (const key in rootNode.properties) {
-        const value = rootNode.properties[key];
-        if (value.node.type === 'array') {
-          value.required = false;
-          collector.push({
-            type: 'ref',
-            ref: `Template<${
-              value.node.elementType.type === 'ref'
-                ? value.node.elementType.ref
-                : value.node.elementType.name
-            }, "${key}">`,
-          });
-        }
-
-        if (value.node.type === 'object') {
-          assetWalker(value.node as NamedType<ObjectType>, collector);
-        }
+export const applyTemplateProperty: TransformFunction = (node, capability) => {
+  const templateTypes: Array<RefType> = [];
+  simpleTransformGenerator('object', 'Assets', (xlrNode) => {
+    for (const key in xlrNode.properties) {
+      const value = xlrNode.properties[key];
+      if (value.node.type === 'array') {
+        value.required = false;
+        templateTypes.push({
+          type: 'ref',
+          ref: `Template<${
+            value.node.elementType.type === 'ref'
+              ? value.node.elementType.ref
+              : value.node.elementType.name
+          }, "${key}">`,
+        });
       }
-    };
-
-    assetWalker(node, templateTypes);
+    }
 
     if (templateTypes.length > 0) {
       const templateType: ArrayType = {
@@ -160,10 +141,10 @@ export const applyTemplateProperty: TransformFunction = (
             : templateTypes[0],
         description: 'A list of templates to process for this node',
       };
-      node.properties.template = {
+      xlrNode.properties.template = {
         required: false,
         node: templateType,
       };
     }
-  }
+  })(node, capability);
 };

--- a/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
@@ -43,10 +43,13 @@ Array [
     "type": "object",
   },
   Object {
-    "additionalProperties": Object {
-      "type": "unknown",
-    },
+    "additionalProperties": false,
     "description": "An asset that contains a Binding.",
+    "extends": Object {
+      "genericArguments": undefined,
+      "ref": "Asset",
+      "type": "ref",
+    },
     "genericTokens": undefined,
     "name": "AssetBinding",
     "properties": Object {
@@ -56,23 +59,6 @@ Array [
           "genericArguments": undefined,
           "ref": "Binding",
           "title": "AssetBinding.binding",
-          "type": "ref",
-        },
-        "required": true,
-      },
-      "id": Object {
-        "node": Object {
-          "description": "Each asset requires a unique id per view",
-          "title": "Asset.id",
-          "type": "string",
-        },
-        "required": true,
-      },
-      "type": Object {
-        "node": Object {
-          "description": "The asset type determines the semantics of how a user interacts with a page",
-          "ref": "T",
-          "title": "Asset.type",
           "type": "ref",
         },
         "required": true,

--- a/xlr/sdk/src/index.ts
+++ b/xlr/sdk/src/index.ts
@@ -1,3 +1,4 @@
 export * from './sdk';
 export * from './types';
 export * from './registry';
+export * from './utils';

--- a/xlr/sdk/src/utils.ts
+++ b/xlr/sdk/src/utils.ts
@@ -17,8 +17,7 @@ export function simpleTransformGenerator<
 >(
   typeToTransform: T,
   capabilityToTransform: string,
-  functionToRun: (input: NodeTypeMap[T]) => void,
-  recursive = true
+  functionToRun: (input: NodeTypeMap[T]) => void
 ): TransformFunction {
   /** walker for an XLR tree to touch every node */
   const walker: TransformFunction = (
@@ -29,10 +28,6 @@ export function simpleTransformGenerator<
     if (capability === capabilityToTransform) {
       if (node.type === typeToTransform) {
         functionToRun(node as unknown as NodeTypeMap[T]);
-      }
-
-      if (!recursive) {
-        return;
       }
 
       if (node.type === 'object') {

--- a/xlr/sdk/src/utils.ts
+++ b/xlr/sdk/src/utils.ts
@@ -1,0 +1,83 @@
+/* eslint-disable guard-for-in */
+/* eslint-disable no-restricted-syntax */
+import type {
+  NamedType,
+  NodeTypeStrings,
+  NodeTypeMap,
+  TransformFunction,
+} from '@player-tools/xlr';
+
+/**
+ * Helper function for simple transforms
+ * Walks an XLR tree looking for the specified node type calls the supplied function when called
+ */
+export function simpleTransformGenerator<
+  T extends NodeTypeStrings = NodeTypeStrings
+>(
+  typeToTransform: T,
+  capabilityToTransform: string,
+  functionToRun: (input: NodeTypeMap[T]) => void
+): TransformFunction {
+  /** walker for an XLR tree to touch every node */
+  const walker: TransformFunction = (node: NamedType, capability: string) => {
+    // Run transform on base node before running on children
+    if (capability === capabilityToTransform) {
+      if (node.type === typeToTransform) {
+        functionToRun(node as unknown as NodeTypeMap[T]);
+      }
+
+      if (node.type === 'object') {
+        if (node.extends) {
+          walker(node, capability);
+        }
+
+        for (const key in node.properties) {
+          const value = node.properties[key];
+          walker(value.node as NamedType, capability);
+        }
+
+        if (node.additionalProperties) {
+          walker(node.additionalProperties as NamedType, capability);
+        }
+      } else if (node.type === 'array') {
+        walker(node.elementType as NamedType, capability);
+      } else if (node.type === 'and') {
+        node.and.forEach((element) => walker(element as NamedType, capability));
+      } else if (node.type === 'or') {
+        node.or.forEach((element) => walker(element as NamedType, capability));
+      } else if (node.type === 'ref') {
+        node.genericArguments?.forEach((element) =>
+          walker(element as NamedType, capability)
+        );
+      } else if (node.type === 'tuple') {
+        if (node.additionalItems) {
+          walker(node.additionalItems as NamedType, capability);
+        }
+
+        node.elementTypes.forEach((element) =>
+          walker(element as NamedType, capability)
+        );
+      } else if (node.type === 'function') {
+        node.parameters.forEach((param) => {
+          walker(param.type as NamedType, capability);
+          if (param.default) {
+            walker(param.default as NamedType, capability);
+          }
+        });
+        if (node.returnType) {
+          walker(node.returnType as NamedType, capability);
+        }
+      } else if (node.type === 'record') {
+        walker(node.keyType as NamedType, capability);
+        walker(node.valueType as NamedType, capability);
+      } else if (node.type === 'conditional') {
+        walker(node.check.left as NamedType, capability);
+        walker(node.check.right as NamedType, capability);
+        walker(node.value.true as NamedType, capability);
+        walker(node.value.false as NamedType, capability);
+      }
+    }
+  };
+
+  return walker;
+}

--- a/xlr/sdk/src/validator.ts
+++ b/xlr/sdk/src/validator.ts
@@ -369,10 +369,12 @@ export class XLRValidator {
     operand: ObjectType,
     errorOnOverlap = true
   ): ObjectType {
+    const baseObjectName = base.name ?? 'object literal';
+    const operandObjectName = operand.name ?? 'object literal';
     const newObject = {
       ...base,
-      name: `${base.name} & ${operand.name}`,
-      description: `Effective type combining ${base.name} and ${operand.name}`,
+      name: `${baseObjectName} & ${operandObjectName}`,
+      description: `Effective type combining ${baseObjectName} and ${operandObjectName}`,
     };
 
     // eslint-disable-next-line no-restricted-syntax, guard-for-in
@@ -384,11 +386,7 @@ export class XLRValidator {
         errorOnOverlap
       ) {
         throw new Error(
-          `Can't compute effective type for ${
-            base.name ?? 'object literal'
-          } and ${
-            operand.name ?? 'object literal'
-          } because of conflicting properties ${property}`
+          `Can't compute effective type for ${baseObjectName} and ${operandObjectName} because of conflicting properties ${property}`
         );
       }
 

--- a/xlr/types/src/core.ts
+++ b/xlr/types/src/core.ts
@@ -100,10 +100,12 @@ export interface ObjectProperty {
   node: NodeType;
 }
 export interface ObjectNode extends TypeNode<'object'> {
-  /** the properties associated with an object */
+  /** The properties associated with an object */
   properties: {
     [name: string]: ObjectProperty;
   };
+  /** A custom primitive that this object extends that is to be resolved when used */
+  extends?: RefType;
   /** What type, if any, of additional properties are allowed on the object */
   additionalProperties: false | NodeType;
 }

--- a/xlr/types/src/core.ts
+++ b/xlr/types/src/core.ts
@@ -226,6 +226,13 @@ export type NodeType =
   | FunctionType
   | ConditionalType;
 
+export type NodeTypeStrings = Pick<NodeType, 'type'>['type'];
+
+export type NodeTypeMap = {
+  // eslint-disable-next-line jsdoc/require-jsdoc, prettier/prettier
+  [K in NodeTypeStrings]: Extract<NodeType,{type: K}>;
+};
+
 export type NamedType<T extends NodeType = NodeType> = T & {
   /** Name of the exported interface/type */
   name: string;

--- a/xlr/types/src/utility.ts
+++ b/xlr/types/src/utility.ts
@@ -1,7 +1,7 @@
 import type { NamedType, NodeType } from '.';
 
 export type TransformFunction = (
-  input: NamedType<NodeType>,
+  input: NamedType<NodeType> | NodeType,
   capabilityType: string
 ) => void;
 


### PR DESCRIPTION
Adds a basic walker function to walk an XLR tree, looking for a specific node type, and run a function to transform that node. This should make basic TransfromFunctions much easier to write as now all the traversal logic is abstracted away.  #3 

## Release Notes
Adds a helper function to make writing recursive TransfromFunctions easier. 