### PR TITLE
Fix only one heritage class being parsed

### DIFF
--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -356,6 +356,42 @@ Array [
 
 exports[`Generic Declarations Implementing Interface with Generics 1`] = `Array []`;
 
+exports[`Generic Declarations Implementing two Interfaces 1`] = `
+Array [
+  Object {
+    "additionalProperties": false,
+    "genericTokens": undefined,
+    "name": "Test",
+    "properties": Object {
+      "bar": Object {
+        "node": Object {
+          "title": "Bar.bar",
+          "type": "string",
+        },
+        "required": true,
+      },
+      "foo": Object {
+        "node": Object {
+          "title": "Foo.foo",
+          "type": "number",
+        },
+        "required": true,
+      },
+      "test": Object {
+        "node": Object {
+          "title": "Test.test",
+          "type": "any",
+        },
+        "required": true,
+      },
+    },
+    "source": "filename.ts",
+    "title": "Test",
+    "type": "object",
+  },
+]
+`;
+
 exports[`Generic Declarations Interface with Generics 1`] = `
 Array [
   Object {

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -168,6 +168,30 @@ describe('Generic Declarations', () => {
 
     expect(XLR).toMatchSnapshot();
   });
+
+  it('Implementing two Interfaces', () => {
+    const sc = `
+
+    interface Foo{
+      foo: number
+    }
+
+    interface Bar{
+      bar: string
+    }
+
+    export interface Test extends Foo, Bar {
+      test: any
+    }
+
+    `;
+
+    const { sf, tc } = setupTestEnv(sc);
+    const converter = new TsConverter(tc);
+    const XLR = converter.convertSourceFile(sf).data.types;
+
+    expect(XLR).toMatchSnapshot();
+  });
 });
 
 describe('Complex Types', () => {


### PR DESCRIPTION
Fixes a bug where only one heritage class expression would be parsed out and merged into the object being converted. 

## Release Notes
Fixed a bug with interfaces that extended more than one other interface. 