### PR TITLE
Additional `Extends` Functionality

### DIFF
--- a/cli/src/commands/xlr/compile.ts
+++ b/cli/src/commands/xlr/compile.ts
@@ -251,11 +251,11 @@ export default class XLRCompile extends BaseCommand {
     const tsManifestFile = `${[...(capabilities.capabilities?.values() ?? [])]
       .flat(2)
       .map((capability) => {
-        return `import ${capability} from './${capability}.json'`;
+        return `const ${capability} = require('./${capability}.json')`;
       })
       .join('\n')}
 
-export default {
+module.exports = {
   "pluginName": "${capabilities.pluginName}",
   "capabilities": {
     ${[...(capabilities.capabilities?.entries() ?? [])]

--- a/cli/src/commands/xlr/compile.ts
+++ b/cli/src/commands/xlr/compile.ts
@@ -131,8 +131,6 @@ export default class XLRCompile extends BaseCommand {
         if (symbol) {
           // look at what they implement
           node.heritageClauses?.forEach((heritage) => {
-            capabilities.pluginName =
-              node.name?.text || capabilities.pluginName;
             heritage.types.forEach((hInterface) => {
               // check if heritage is right one
               if (
@@ -140,6 +138,18 @@ export default class XLRCompile extends BaseCommand {
               ) {
                 return;
               }
+
+              // Get registration name of plugin
+              node.members.forEach((member) => {
+                if (
+                  ts.isPropertyDeclaration(member) &&
+                  member.name.getText() === 'name'
+                ) {
+                  capabilities.pluginName =
+                    member.initializer?.getText().replace(/['"]+/g, '') ??
+                    'Unknown Plugin';
+                }
+              });
 
               const provides: Map<string, Array<string>> = new Map();
               const typeArgs = hInterface.typeArguments;

--- a/cli/src/commands/xlr/compile.ts
+++ b/cli/src/commands/xlr/compile.ts
@@ -140,16 +140,16 @@ export default class XLRCompile extends BaseCommand {
               }
 
               // Get registration name of plugin
-              node.members.forEach((member) => {
-                if (
+              const nameProperty = node.members.find(
+                (member) =>
                   ts.isPropertyDeclaration(member) &&
-                  member.name.getText() === 'name'
-                ) {
-                  capabilities.pluginName =
-                    member.initializer?.getText().replace(/['"]+/g, '') ??
-                    'Unknown Plugin';
-                }
-              });
+                  member.name?.getText() === 'name'
+              ) as ts.PropertyDeclaration | undefined;
+              if (nameProperty && nameProperty.initializer) {
+                capabilities.pluginName = nameProperty.initializer
+                  ?.getText()
+                  .replace(/['"]+/g, '');
+              }
 
               const provides: Map<string, Array<string>> = new Map();
               const typeArgs = hInterface.typeArguments;

--- a/cli/src/utils/base-command.ts
+++ b/cli/src/utils/base-command.ts
@@ -25,6 +25,8 @@ export abstract class BaseCommand extends Command {
     }),
   };
 
+  static strict = false;
+
   private resolvedConfig: PlayerConfigResolvedShape | undefined;
 
   private async loadConfig(configFilePath?: string) {

--- a/common/BUILD
+++ b/common/BUILD
@@ -1,4 +1,5 @@
-load("@rules_player//javascript/package_json:index.bzl", "merge_json", "create_contributors")
+load("@rules_player//javascript/package_json:index.bzl", "merge_json", "create_contributors", "create_package_json")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
 load("//:index.bzl", "GIT_REPO", "LICENSE", "DOCS_URL", "REPO_URL", "ISSUES_URL")
 package(default_visibility = ["//visibility:public"])
 
@@ -6,6 +7,30 @@ filegroup(
     name = "static_xlrs",
     srcs = glob(["static_xlrs/**"])
 )
+
+# Should split this up into 2 modules
+
+create_package_json(
+    name = "xlr_pkg_json",
+    package_name = "@player-tools/static-xlrs",
+    entry = "index.js",
+    out_dir = "dist",
+    root_package_json = "//:package.json",
+    private = True,
+    dependencies = [],
+)
+
+js_library(
+    name = "@player-tools/static-xlrs",
+    srcs=[
+        ":static_xlrs",
+    ],
+    package_name = "@player-tools/static-xlrs",
+    deps = [
+        ":xlr_pkg_json"
+    ]
+)
+
 
 create_contributors(
     name = "pkg_json_contrib",

--- a/common/static_xlrs/core/xlr/AssetBinding.json
+++ b/common/static_xlrs/core/xlr/AssetBinding.json
@@ -3,23 +3,6 @@
     "type": "object",
     "source": "src/index.ts",
     "properties": {
-        "id": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "title": "Asset.id",
-                "description": "Each asset requires a unique id per view"
-            }
-        },
-        "type": {
-            "required": true,
-            "node": {
-                "type": "ref",
-                "ref": "T",
-                "title": "Asset.type",
-                "description": "The asset type determines the semantics of how a user interacts with a page"
-            }
-        },
         "binding": {
             "required": true,
             "node": {
@@ -30,9 +13,11 @@
             }
         }
     },
-    "additionalProperties": {
-        "type": "unknown"
-    },
+    "additionalProperties": false,
     "title": "AssetBinding",
-    "description": "An asset that contains a Binding."
+    "description": "An asset that contains a Binding.",
+    "extends": {
+        "type": "ref",
+        "ref": "Asset"
+    }
 }

--- a/common/static_xlrs/core/xlr/Flow.json
+++ b/common/static_xlrs/core/xlr/Flow.json
@@ -17,145 +17,164 @@
                 "type": "array",
                 "elementType": {
                     "name": "View",
-                    "title": "View",
                     "source": "src/index.ts",
-                    "type": "and",
-                    "and": [
-                        {
+                    "type": "conditional",
+                    "check": {
+                        "left": {
+                            "type": "unknown"
+                        },
+                        "right": {
+                            "type": "ref",
+                            "ref": "Asset",
+                            "property": "validation"
+                        }
+                    },
+                    "value": {
+                        "true": {
+                            "type": "and",
+                            "and": [
+                                {
+                                    "type": "ref",
+                                    "ref": "T"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "validation": {
+                                            "required": false,
+                                            "node": {
+                                                "type": "array",
+                                                "elementType": {
+                                                    "name": "CrossfieldReference",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "required": true,
+                                                            "node": {
+                                                                "type": "string",
+                                                                "title": "Reference.type",
+                                                                "description": "The name of the referenced validation type\nThis will be used to lookup the proper handler"
+                                                            }
+                                                        },
+                                                        "message": {
+                                                            "required": false,
+                                                            "node": {
+                                                                "type": "string",
+                                                                "title": "Reference.message",
+                                                                "description": "An optional means of overriding the default message if the validation is triggered"
+                                                            }
+                                                        },
+                                                        "severity": {
+                                                            "required": false,
+                                                            "node": {
+                                                                "name": "Severity",
+                                                                "type": "or",
+                                                                "or": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "const": "error",
+                                                                        "title": "Severity"
+                                                                    },
+                                                                    {
+                                                                        "type": "string",
+                                                                        "const": "warning",
+                                                                        "title": "Severity"
+                                                                    }
+                                                                ],
+                                                                "title": "Reference.severity",
+                                                                "description": "An optional means of overriding the default severity of the validation if triggered"
+                                                            }
+                                                        },
+                                                        "trigger": {
+                                                            "required": false,
+                                                            "node": {
+                                                                "name": "Trigger",
+                                                                "type": "or",
+                                                                "or": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "const": "navigation",
+                                                                        "title": "Trigger"
+                                                                    },
+                                                                    {
+                                                                        "type": "string",
+                                                                        "const": "change",
+                                                                        "title": "Trigger"
+                                                                    },
+                                                                    {
+                                                                        "type": "string",
+                                                                        "const": "load",
+                                                                        "title": "Trigger"
+                                                                    }
+                                                                ],
+                                                                "title": "Reference.trigger",
+                                                                "description": "When to run this particular validation"
+                                                            }
+                                                        },
+                                                        "dataTarget": {
+                                                            "required": false,
+                                                            "node": {
+                                                                "type": "never",
+                                                                "title": "CrossfieldReference.dataTarget",
+                                                                "description": "Cross-field references and validation must run against the default (deformatted) value"
+                                                            }
+                                                        },
+                                                        "displayTarget": {
+                                                            "required": false,
+                                                            "node": {
+                                                                "name": "DisplayTarget",
+                                                                "type": "or",
+                                                                "or": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "const": "page",
+                                                                        "title": "DisplayTarget"
+                                                                    },
+                                                                    {
+                                                                        "type": "string",
+                                                                        "const": "section",
+                                                                        "title": "DisplayTarget"
+                                                                    },
+                                                                    {
+                                                                        "type": "string",
+                                                                        "const": "field",
+                                                                        "title": "DisplayTarget"
+                                                                    }
+                                                                ],
+                                                                "title": "Reference.displayTarget",
+                                                                "description": "Where the error should be displayed"
+                                                            }
+                                                        },
+                                                        "ref": {
+                                                            "required": false,
+                                                            "node": {
+                                                                "type": "ref",
+                                                                "ref": "Binding",
+                                                                "title": "CrossfieldReference.ref",
+                                                                "description": "The binding to associate this validation with"
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": {
+                                                        "type": "unknown"
+                                                    },
+                                                    "title": "CrossfieldReference"
+                                                },
+                                                "title": "validation",
+                                                "description": "Each view can optionally supply a list of validations to run against a particular view"
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            ]
+                        },
+                        "false": {
                             "type": "ref",
                             "ref": "T"
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "validation": {
-                                    "required": false,
-                                    "node": {
-                                        "type": "array",
-                                        "elementType": {
-                                            "name": "CrossfieldReference",
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "required": true,
-                                                    "node": {
-                                                        "type": "string",
-                                                        "title": "Reference.type",
-                                                        "description": "The name of the referenced validation type\nThis will be used to lookup the proper handler"
-                                                    }
-                                                },
-                                                "message": {
-                                                    "required": false,
-                                                    "node": {
-                                                        "type": "string",
-                                                        "title": "Reference.message",
-                                                        "description": "An optional means of overriding the default message if the validation is triggered"
-                                                    }
-                                                },
-                                                "severity": {
-                                                    "required": false,
-                                                    "node": {
-                                                        "name": "Severity",
-                                                        "type": "or",
-                                                        "or": [
-                                                            {
-                                                                "type": "string",
-                                                                "const": "error",
-                                                                "title": "Severity"
-                                                            },
-                                                            {
-                                                                "type": "string",
-                                                                "const": "warning",
-                                                                "title": "Severity"
-                                                            }
-                                                        ],
-                                                        "title": "Reference.severity",
-                                                        "description": "An optional means of overriding the default severity of the validation if triggered"
-                                                    }
-                                                },
-                                                "trigger": {
-                                                    "required": false,
-                                                    "node": {
-                                                        "name": "Trigger",
-                                                        "type": "or",
-                                                        "or": [
-                                                            {
-                                                                "type": "string",
-                                                                "const": "navigation",
-                                                                "title": "Trigger"
-                                                            },
-                                                            {
-                                                                "type": "string",
-                                                                "const": "change",
-                                                                "title": "Trigger"
-                                                            },
-                                                            {
-                                                                "type": "string",
-                                                                "const": "load",
-                                                                "title": "Trigger"
-                                                            }
-                                                        ],
-                                                        "title": "Reference.trigger",
-                                                        "description": "When to run this particular validation"
-                                                    }
-                                                },
-                                                "dataTarget": {
-                                                    "required": false,
-                                                    "node": {
-                                                        "type": "never",
-                                                        "title": "CrossfieldReference.dataTarget",
-                                                        "description": "Cross-field references and validation must run against the default (deformatted) value"
-                                                    }
-                                                },
-                                                "displayTarget": {
-                                                    "required": false,
-                                                    "node": {
-                                                        "name": "DisplayTarget",
-                                                        "type": "or",
-                                                        "or": [
-                                                            {
-                                                                "type": "string",
-                                                                "const": "page",
-                                                                "title": "DisplayTarget"
-                                                            },
-                                                            {
-                                                                "type": "string",
-                                                                "const": "section",
-                                                                "title": "DisplayTarget"
-                                                            },
-                                                            {
-                                                                "type": "string",
-                                                                "const": "field",
-                                                                "title": "DisplayTarget"
-                                                            }
-                                                        ],
-                                                        "title": "Reference.displayTarget",
-                                                        "description": "Where the error should be displayed"
-                                                    }
-                                                },
-                                                "ref": {
-                                                    "required": false,
-                                                    "node": {
-                                                        "type": "ref",
-                                                        "ref": "Binding",
-                                                        "title": "CrossfieldReference.ref",
-                                                        "description": "The binding to associate this validation with"
-                                                    }
-                                                }
-                                            },
-                                            "additionalProperties": {
-                                                "type": "unknown"
-                                            },
-                                            "title": "CrossfieldReference"
-                                        },
-                                        "title": "validation",
-                                        "description": "Each view can optionally supply a list of validations to run against a particular view"
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
                         }
-                    ],
+                    },
+                    "title": "View",
                     "genericTokens": [
                         {
                             "symbol": "T",
@@ -617,771 +636,783 @@
             "node": {
                 "name": "Navigation",
                 "source": "src/index.ts",
-                "type": "object",
-                "properties": {
-                    "BEGIN": {
-                        "required": true,
-                        "node": {
-                            "type": "string",
-                            "title": "Navigation.BEGIN",
-                            "description": "The name of the Flow to begin on"
-                        }
-                    }
-                },
-                "additionalProperties": {
-                    "type": "or",
-                    "or": [
-                        {
+                "type": "and",
+                "and": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "BEGIN": {
+                                "required": true,
+                                "node": {
+                                    "type": "string",
+                                    "title": "BEGIN",
+                                    "description": "The name of the Flow to begin on"
+                                }
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "record",
+                        "keyType": {
                             "type": "string"
                         },
-                        {
-                            "name": "NavigationFlow",
-                            "type": "object",
-                            "source": "src/index.ts",
-                            "properties": {
-                                "startState": {
-                                    "required": true,
-                                    "node": {
-                                        "type": "string",
-                                        "title": "NavigationFlow.startState",
-                                        "description": "The first state to kick off the state machine"
-                                    }
+                        "valueType": {
+                            "type": "or",
+                            "or": [
+                                {
+                                    "type": "string"
                                 },
-                                "onStart": {
-                                    "required": false,
-                                    "node": {
-                                        "type": "or",
-                                        "or": [
-                                            {
-                                                "type": "ref",
-                                                "ref": "Expression",
-                                                "title": "NavigationFlow.onStart"
-                                            },
-                                            {
-                                                "name": "ExpressionObject",
-                                                "type": "object",
-                                                "source": "src/index.ts",
-                                                "properties": {
-                                                    "exp": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "ref",
-                                                            "ref": "Expression",
-                                                            "title": "ExpressionObject.exp",
-                                                            "description": "The expression to run"
-                                                        }
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "title": "ExpressionObject",
-                                                "description": "An object with an expression in it"
-                                            }
-                                        ],
-                                        "title": "NavigationFlow.onStart",
-                                        "description": "An optional expression to run when this Flow starts"
-                                    }
-                                },
-                                "onEnd": {
-                                    "required": false,
-                                    "node": {
-                                        "type": "or",
-                                        "or": [
-                                            {
-                                                "type": "ref",
-                                                "ref": "Expression",
-                                                "title": "NavigationFlow.onEnd"
-                                            },
-                                            {
-                                                "name": "ExpressionObject",
-                                                "type": "object",
-                                                "source": "src/index.ts",
-                                                "properties": {
-                                                    "exp": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "ref",
-                                                            "ref": "Expression",
-                                                            "title": "ExpressionObject.exp",
-                                                            "description": "The expression to run"
-                                                        }
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "title": "ExpressionObject",
-                                                "description": "An object with an expression in it"
-                                            }
-                                        ],
-                                        "title": "NavigationFlow.onEnd",
-                                        "description": "An optional expression to run when this Flow ends"
-                                    }
-                                }
-                            },
-                            "additionalProperties": {
-                                "type": "or",
-                                "or": [
-                                    {
-                                        "type": "undefined"
-                                    },
-                                    {
-                                        "type": "string"
-                                    },
-                                    {
-                                        "type": "ref",
-                                        "ref": "Expression"
-                                    },
-                                    {
-                                        "name": "ExpressionObject",
-                                        "type": "object",
-                                        "source": "src/index.ts",
-                                        "properties": {
-                                            "exp": {
-                                                "required": false,
-                                                "node": {
-                                                    "type": "ref",
-                                                    "ref": "Expression",
-                                                    "title": "ExpressionObject.exp",
-                                                    "description": "The expression to run"
-                                                }
+                                {
+                                    "name": "NavigationFlow",
+                                    "type": "object",
+                                    "source": "src/index.ts",
+                                    "properties": {
+                                        "startState": {
+                                            "required": true,
+                                            "node": {
+                                                "type": "string",
+                                                "title": "NavigationFlow.startState",
+                                                "description": "The first state to kick off the state machine"
                                             }
                                         },
-                                        "additionalProperties": false,
-                                        "title": "ExpressionObject",
-                                        "description": "An object with an expression in it"
+                                        "onStart": {
+                                            "required": false,
+                                            "node": {
+                                                "type": "or",
+                                                "or": [
+                                                    {
+                                                        "type": "ref",
+                                                        "ref": "Expression",
+                                                        "title": "NavigationFlow.onStart"
+                                                    },
+                                                    {
+                                                        "name": "ExpressionObject",
+                                                        "type": "object",
+                                                        "source": "src/index.ts",
+                                                        "properties": {
+                                                            "exp": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "ref",
+                                                                    "ref": "Expression",
+                                                                    "title": "ExpressionObject.exp",
+                                                                    "description": "The expression to run"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "title": "ExpressionObject",
+                                                        "description": "An object with an expression in it"
+                                                    }
+                                                ],
+                                                "title": "NavigationFlow.onStart",
+                                                "description": "An optional expression to run when this Flow starts"
+                                            }
+                                        },
+                                        "onEnd": {
+                                            "required": false,
+                                            "node": {
+                                                "type": "or",
+                                                "or": [
+                                                    {
+                                                        "type": "ref",
+                                                        "ref": "Expression",
+                                                        "title": "NavigationFlow.onEnd"
+                                                    },
+                                                    {
+                                                        "name": "ExpressionObject",
+                                                        "type": "object",
+                                                        "source": "src/index.ts",
+                                                        "properties": {
+                                                            "exp": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "ref",
+                                                                    "ref": "Expression",
+                                                                    "title": "ExpressionObject.exp",
+                                                                    "description": "The expression to run"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "title": "ExpressionObject",
+                                                        "description": "An object with an expression in it"
+                                                    }
+                                                ],
+                                                "title": "NavigationFlow.onEnd",
+                                                "description": "An optional expression to run when this Flow ends"
+                                            }
+                                        }
                                     },
-                                    {
-                                        "name": "NavigationFlowState",
-                                        "source": "src/index.ts",
+                                    "additionalProperties": {
                                         "type": "or",
                                         "or": [
                                             {
-                                                "name": "NavigationFlowViewState",
-                                                "type": "object",
-                                                "source": "src/index.ts",
-                                                "properties": {
-                                                    "_comment": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "CommentBase._comment",
-                                                            "description": "Add comments that will not be processing, but are useful for code explanation"
-                                                        }
-                                                    },
-                                                    "state_type": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "const": "VIEW",
-                                                            "title": "NavigationBaseState.state_type",
-                                                            "description": "A property to determine the type of state this is"
-                                                        }
-                                                    },
-                                                    "onStart": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onStart"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
-                                                                }
-                                                            ],
-                                                            "title": "NavigationBaseState.onStart",
-                                                            "description": "An optional expression to run when this view renders"
-                                                        }
-                                                    },
-                                                    "onEnd": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onEnd"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
-                                                                }
-                                                            ],
-                                                            "title": "NavigationBaseState.onEnd",
-                                                            "description": "An optional expression to run before view transition"
-                                                        }
-                                                    },
-                                                    "exp": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "title": "NavigationBaseState.exp",
-                                                            "type": "never"
-                                                        }
-                                                    },
-                                                    "transitions": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "name": "NavigationFlowTransition",
-                                                            "source": "src/index.ts",
-                                                            "type": "record",
-                                                            "keyType": {
-                                                                "type": "string"
-                                                            },
-                                                            "valueType": {
-                                                                "type": "string"
-                                                            },
-                                                            "title": "NavigationFlowTransitionableState.transitions",
-                                                            "description": "A mapping of transition-name to FlowState name"
-                                                        }
-                                                    },
-                                                    "ref": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "NavigationFlowViewState.ref",
-                                                            "description": "An id corresponding to a view from the 'views' array"
-                                                        }
-                                                    },
-                                                    "attributes": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "object",
-                                                            "properties": {},
-                                                            "additionalProperties": {
-                                                                "type": "any"
-                                                            },
-                                                            "title": "NavigationFlowViewState.attributes",
-                                                            "description": "View meta-properties"
-                                                        }
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "title": "NavigationFlowViewState",
-                                                "description": "A state representing a view"
+                                                "type": "undefined"
                                             },
                                             {
-                                                "name": "NavigationFlowEndState",
-                                                "type": "object",
-                                                "source": "src/index.ts",
-                                                "properties": {
-                                                    "_comment": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "CommentBase._comment",
-                                                            "description": "Add comments that will not be processing, but are useful for code explanation"
-                                                        }
-                                                    },
-                                                    "state_type": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "const": "END",
-                                                            "title": "NavigationBaseState.state_type",
-                                                            "description": "A property to determine the type of state this is"
-                                                        }
-                                                    },
-                                                    "onStart": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onStart"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
-                                                                }
-                                                            ],
-                                                            "title": "NavigationBaseState.onStart",
-                                                            "description": "An optional expression to run when this view renders"
-                                                        }
-                                                    },
-                                                    "onEnd": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onEnd"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
-                                                                }
-                                                            ],
-                                                            "title": "NavigationBaseState.onEnd",
-                                                            "description": "An optional expression to run before view transition"
-                                                        }
-                                                    },
-                                                    "exp": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "title": "NavigationBaseState.exp",
-                                                            "type": "never"
-                                                        }
-                                                    },
-                                                    "outcome": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "NavigationFlowEndState.outcome",
-                                                            "description": "A description of _how_ the flow ended.\nIf this is a flow started from another flow, the outcome determines the flow transition"
-                                                        }
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "title": "NavigationFlowEndState",
-                                                "description": "An END state of the flow."
+                                                "type": "string"
                                             },
                                             {
-                                                "name": "NavigationFlowFlowState",
-                                                "type": "object",
-                                                "source": "src/index.ts",
-                                                "properties": {
-                                                    "_comment": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "CommentBase._comment",
-                                                            "description": "Add comments that will not be processing, but are useful for code explanation"
-                                                        }
-                                                    },
-                                                    "state_type": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "const": "FLOW",
-                                                            "title": "NavigationBaseState.state_type",
-                                                            "description": "A property to determine the type of state this is"
-                                                        }
-                                                    },
-                                                    "onStart": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onStart"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
-                                                                }
-                                                            ],
-                                                            "title": "NavigationBaseState.onStart",
-                                                            "description": "An optional expression to run when this view renders"
-                                                        }
-                                                    },
-                                                    "onEnd": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onEnd"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
-                                                                }
-                                                            ],
-                                                            "title": "NavigationBaseState.onEnd",
-                                                            "description": "An optional expression to run before view transition"
-                                                        }
-                                                    },
-                                                    "exp": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "title": "NavigationBaseState.exp",
-                                                            "type": "never"
-                                                        }
-                                                    },
-                                                    "transitions": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "name": "NavigationFlowTransition",
-                                                            "source": "src/index.ts",
-                                                            "type": "record",
-                                                            "keyType": {
-                                                                "type": "string"
-                                                            },
-                                                            "valueType": {
-                                                                "type": "string"
-                                                            },
-                                                            "title": "NavigationFlowTransitionableState.transitions",
-                                                            "description": "A mapping of transition-name to FlowState name"
-                                                        }
-                                                    },
-                                                    "ref": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "NavigationFlowFlowState.ref",
-                                                            "description": "A reference to a FLOW id state to run"
-                                                        }
-                                                    }
-                                                },
-                                                "additionalProperties": false,
-                                                "title": "NavigationFlowFlowState"
+                                                "type": "ref",
+                                                "ref": "Expression"
                                             },
                                             {
-                                                "name": "NavigationFlowActionState",
+                                                "name": "ExpressionObject",
                                                 "type": "object",
                                                 "source": "src/index.ts",
                                                 "properties": {
-                                                    "_comment": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "CommentBase._comment",
-                                                            "description": "Add comments that will not be processing, but are useful for code explanation"
-                                                        }
-                                                    },
-                                                    "state_type": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "const": "ACTION",
-                                                            "title": "NavigationBaseState.state_type",
-                                                            "description": "A property to determine the type of state this is"
-                                                        }
-                                                    },
-                                                    "onStart": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onStart"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
-                                                                }
-                                                            ],
-                                                            "title": "NavigationBaseState.onStart",
-                                                            "description": "An optional expression to run when this view renders"
-                                                        }
-                                                    },
-                                                    "onEnd": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onEnd"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
-                                                                }
-                                                            ],
-                                                            "title": "NavigationBaseState.onEnd",
-                                                            "description": "An optional expression to run before view transition"
-                                                        }
-                                                    },
                                                     "exp": {
-                                                        "required": true,
+                                                        "required": false,
                                                         "node": {
                                                             "type": "ref",
                                                             "ref": "Expression",
-                                                            "title": "NavigationFlowActionState.exp",
-                                                            "description": "An expression to execute.\nThe return value determines the transition to take"
-                                                        }
-                                                    },
-                                                    "transitions": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "name": "NavigationFlowTransition",
-                                                            "source": "src/index.ts",
-                                                            "type": "record",
-                                                            "keyType": {
-                                                                "type": "string"
-                                                            },
-                                                            "valueType": {
-                                                                "type": "string"
-                                                            },
-                                                            "title": "NavigationFlowTransitionableState.transitions",
-                                                            "description": "A mapping of transition-name to FlowState name"
+                                                            "title": "ExpressionObject.exp",
+                                                            "description": "The expression to run"
                                                         }
                                                     }
                                                 },
                                                 "additionalProperties": false,
-                                                "title": "NavigationFlowActionState",
-                                                "description": "Action states execute an expression to determine the next state to transition to"
+                                                "title": "ExpressionObject",
+                                                "description": "An object with an expression in it"
                                             },
                                             {
-                                                "name": "NavigationFlowExternalState",
-                                                "type": "object",
+                                                "name": "NavigationFlowState",
                                                 "source": "src/index.ts",
-                                                "properties": {
-                                                    "_comment": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "CommentBase._comment",
-                                                            "description": "Add comments that will not be processing, but are useful for code explanation"
-                                                        }
+                                                "type": "or",
+                                                "or": [
+                                                    {
+                                                        "name": "NavigationFlowViewState",
+                                                        "type": "object",
+                                                        "source": "src/index.ts",
+                                                        "properties": {
+                                                            "_comment": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "CommentBase._comment",
+                                                                    "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                                }
+                                                            },
+                                                            "state_type": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "const": "VIEW",
+                                                                    "title": "NavigationBaseState.state_type",
+                                                                    "description": "A property to determine the type of state this is"
+                                                                }
+                                                            },
+                                                            "onStart": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onStart"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onStart",
+                                                                    "description": "An optional expression to run when this view renders"
+                                                                }
+                                                            },
+                                                            "onEnd": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onEnd"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onEnd",
+                                                                    "description": "An optional expression to run before view transition"
+                                                                }
+                                                            },
+                                                            "exp": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "title": "NavigationBaseState.exp",
+                                                                    "type": "never"
+                                                                }
+                                                            },
+                                                            "transitions": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "name": "NavigationFlowTransition",
+                                                                    "source": "src/index.ts",
+                                                                    "type": "record",
+                                                                    "keyType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "valueType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "title": "NavigationFlowTransitionableState.transitions",
+                                                                    "description": "A mapping of transition-name to FlowState name"
+                                                                }
+                                                            },
+                                                            "ref": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "NavigationFlowViewState.ref",
+                                                                    "description": "An id corresponding to a view from the 'views' array"
+                                                                }
+                                                            },
+                                                            "attributes": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "object",
+                                                                    "properties": {},
+                                                                    "additionalProperties": {
+                                                                        "type": "any"
+                                                                    },
+                                                                    "title": "NavigationFlowViewState.attributes",
+                                                                    "description": "View meta-properties"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "title": "NavigationFlowViewState",
+                                                        "description": "A state representing a view"
                                                     },
-                                                    "state_type": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "const": "EXTERNAL",
-                                                            "title": "NavigationBaseState.state_type",
-                                                            "description": "A property to determine the type of state this is"
-                                                        }
+                                                    {
+                                                        "name": "NavigationFlowEndState",
+                                                        "type": "object",
+                                                        "source": "src/index.ts",
+                                                        "properties": {
+                                                            "_comment": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "CommentBase._comment",
+                                                                    "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                                }
+                                                            },
+                                                            "state_type": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "const": "END",
+                                                                    "title": "NavigationBaseState.state_type",
+                                                                    "description": "A property to determine the type of state this is"
+                                                                }
+                                                            },
+                                                            "onStart": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onStart"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onStart",
+                                                                    "description": "An optional expression to run when this view renders"
+                                                                }
+                                                            },
+                                                            "onEnd": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onEnd"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onEnd",
+                                                                    "description": "An optional expression to run before view transition"
+                                                                }
+                                                            },
+                                                            "exp": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "title": "NavigationBaseState.exp",
+                                                                    "type": "never"
+                                                                }
+                                                            },
+                                                            "outcome": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "NavigationFlowEndState.outcome",
+                                                                    "description": "A description of _how_ the flow ended.\nIf this is a flow started from another flow, the outcome determines the flow transition"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "title": "NavigationFlowEndState",
+                                                        "description": "An END state of the flow."
                                                     },
-                                                    "onStart": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
+                                                    {
+                                                        "name": "NavigationFlowFlowState",
+                                                        "type": "object",
+                                                        "source": "src/index.ts",
+                                                        "properties": {
+                                                            "_comment": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "CommentBase._comment",
+                                                                    "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                                }
+                                                            },
+                                                            "state_type": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "const": "FLOW",
+                                                                    "title": "NavigationBaseState.state_type",
+                                                                    "description": "A property to determine the type of state this is"
+                                                                }
+                                                            },
+                                                            "onStart": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onStart"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onStart",
+                                                                    "description": "An optional expression to run when this view renders"
+                                                                }
+                                                            },
+                                                            "onEnd": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onEnd"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onEnd",
+                                                                    "description": "An optional expression to run before view transition"
+                                                                }
+                                                            },
+                                                            "exp": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "title": "NavigationBaseState.exp",
+                                                                    "type": "never"
+                                                                }
+                                                            },
+                                                            "transitions": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "name": "NavigationFlowTransition",
+                                                                    "source": "src/index.ts",
+                                                                    "type": "record",
+                                                                    "keyType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "valueType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "title": "NavigationFlowTransitionableState.transitions",
+                                                                    "description": "A mapping of transition-name to FlowState name"
+                                                                }
+                                                            },
+                                                            "ref": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "NavigationFlowFlowState.ref",
+                                                                    "description": "A reference to a FLOW id state to run"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "title": "NavigationFlowFlowState"
+                                                    },
+                                                    {
+                                                        "name": "NavigationFlowActionState",
+                                                        "type": "object",
+                                                        "source": "src/index.ts",
+                                                        "properties": {
+                                                            "_comment": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "CommentBase._comment",
+                                                                    "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                                }
+                                                            },
+                                                            "state_type": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "const": "ACTION",
+                                                                    "title": "NavigationBaseState.state_type",
+                                                                    "description": "A property to determine the type of state this is"
+                                                                }
+                                                            },
+                                                            "onStart": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onStart"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onStart",
+                                                                    "description": "An optional expression to run when this view renders"
+                                                                }
+                                                            },
+                                                            "onEnd": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onEnd"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onEnd",
+                                                                    "description": "An optional expression to run before view transition"
+                                                                }
+                                                            },
+                                                            "exp": {
+                                                                "required": true,
+                                                                "node": {
                                                                     "type": "ref",
                                                                     "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onStart"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
-                                                                    "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
+                                                                    "title": "NavigationFlowActionState.exp",
+                                                                    "description": "An expression to execute.\nThe return value determines the transition to take"
                                                                 }
-                                                            ],
-                                                            "title": "NavigationBaseState.onStart",
-                                                            "description": "An optional expression to run when this view renders"
-                                                        }
-                                                    },
-                                                    "onEnd": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "type": "or",
-                                                            "or": [
-                                                                {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "NavigationBaseState.onEnd"
-                                                                },
-                                                                {
-                                                                    "name": "ExpressionObject",
-                                                                    "type": "object",
+                                                            },
+                                                            "transitions": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "name": "NavigationFlowTransition",
                                                                     "source": "src/index.ts",
-                                                                    "properties": {
-                                                                        "exp": {
-                                                                            "required": false,
-                                                                            "node": {
-                                                                                "type": "ref",
-                                                                                "ref": "Expression",
-                                                                                "title": "ExpressionObject.exp",
-                                                                                "description": "The expression to run"
-                                                                            }
-                                                                        }
+                                                                    "type": "record",
+                                                                    "keyType": {
+                                                                        "type": "string"
                                                                     },
-                                                                    "additionalProperties": false,
-                                                                    "title": "ExpressionObject",
-                                                                    "description": "An object with an expression in it"
+                                                                    "valueType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "title": "NavigationFlowTransitionableState.transitions",
+                                                                    "description": "A mapping of transition-name to FlowState name"
                                                                 }
-                                                            ],
-                                                            "title": "NavigationBaseState.onEnd",
-                                                            "description": "An optional expression to run before view transition"
-                                                        }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "title": "NavigationFlowActionState",
+                                                        "description": "Action states execute an expression to determine the next state to transition to"
                                                     },
-                                                    "exp": {
-                                                        "required": false,
-                                                        "node": {
-                                                            "title": "NavigationBaseState.exp",
-                                                            "type": "never"
-                                                        }
-                                                    },
-                                                    "transitions": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "name": "NavigationFlowTransition",
-                                                            "source": "src/index.ts",
-                                                            "type": "record",
-                                                            "keyType": {
-                                                                "type": "string"
+                                                    {
+                                                        "name": "NavigationFlowExternalState",
+                                                        "type": "object",
+                                                        "source": "src/index.ts",
+                                                        "properties": {
+                                                            "_comment": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "CommentBase._comment",
+                                                                    "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                                }
                                                             },
-                                                            "valueType": {
-                                                                "type": "string"
+                                                            "state_type": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "const": "EXTERNAL",
+                                                                    "title": "NavigationBaseState.state_type",
+                                                                    "description": "A property to determine the type of state this is"
+                                                                }
                                                             },
-                                                            "title": "NavigationFlowTransitionableState.transitions",
-                                                            "description": "A mapping of transition-name to FlowState name"
-                                                        }
-                                                    },
-                                                    "ref": {
-                                                        "required": true,
-                                                        "node": {
-                                                            "type": "string",
-                                                            "title": "NavigationFlowExternalState.ref",
-                                                            "description": "A reference for this external state"
-                                                        }
+                                                            "onStart": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onStart"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onStart",
+                                                                    "description": "An optional expression to run when this view renders"
+                                                                }
+                                                            },
+                                                            "onEnd": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "type": "or",
+                                                                    "or": [
+                                                                        {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "NavigationBaseState.onEnd"
+                                                                        },
+                                                                        {
+                                                                            "name": "ExpressionObject",
+                                                                            "type": "object",
+                                                                            "source": "src/index.ts",
+                                                                            "properties": {
+                                                                                "exp": {
+                                                                                    "required": false,
+                                                                                    "node": {
+                                                                                        "type": "ref",
+                                                                                        "ref": "Expression",
+                                                                                        "title": "ExpressionObject.exp",
+                                                                                        "description": "The expression to run"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false,
+                                                                            "title": "ExpressionObject",
+                                                                            "description": "An object with an expression in it"
+                                                                        }
+                                                                    ],
+                                                                    "title": "NavigationBaseState.onEnd",
+                                                                    "description": "An optional expression to run before view transition"
+                                                                }
+                                                            },
+                                                            "exp": {
+                                                                "required": false,
+                                                                "node": {
+                                                                    "title": "NavigationBaseState.exp",
+                                                                    "type": "never"
+                                                                }
+                                                            },
+                                                            "transitions": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "name": "NavigationFlowTransition",
+                                                                    "source": "src/index.ts",
+                                                                    "type": "record",
+                                                                    "keyType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "valueType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "title": "NavigationFlowTransitionableState.transitions",
+                                                                    "description": "A mapping of transition-name to FlowState name"
+                                                                }
+                                                            },
+                                                            "ref": {
+                                                                "required": true,
+                                                                "node": {
+                                                                    "type": "string",
+                                                                    "title": "NavigationFlowExternalState.ref",
+                                                                    "description": "A reference for this external state"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "title": "NavigationFlowExternalState",
+                                                        "description": "External Flow states represent states in the FSM that can't be resolved internally in Player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
                                                     }
-                                                },
-                                                "additionalProperties": false,
-                                                "title": "NavigationFlowExternalState",
-                                                "description": "External Flow states represent states in the FSM that can't be resolved internally in the player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
+                                                ],
+                                                "title": "NavigationFlowState"
                                             }
-                                        ],
-                                        "title": "NavigationFlowState"
-                                    }
-                                ]
-                            },
-                            "title": "NavigationFlow",
-                            "description": "A state machine in the navigation"
+                                        ]
+                                    },
+                                    "title": "NavigationFlow",
+                                    "description": "A state machine in the navigation"
+                                }
+                            ]
                         }
-                    ]
-                },
+                    }
+                ],
                 "title": "Flow.navigation",
                 "description": "A state machine to drive a user through the experience"
             }
@@ -1391,7 +1422,7 @@
         "type": "unknown"
     },
     "title": "Flow",
-    "description": "The JSON payload for running the player",
+    "description": "The JSON payload for running Player",
     "genericTokens": [
         {
             "symbol": "T",

--- a/common/static_xlrs/core/xlr/Navigation.json
+++ b/common/static_xlrs/core/xlr/Navigation.json
@@ -1,771 +1,783 @@
 {
     "name": "Navigation",
     "source": "src/index.ts",
-    "type": "object",
-    "properties": {
-        "BEGIN": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "title": "Navigation.BEGIN",
-                "description": "The name of the Flow to begin on"
-            }
-        }
-    },
-    "additionalProperties": {
-        "type": "or",
-        "or": [
-            {
+    "type": "and",
+    "and": [
+        {
+            "type": "object",
+            "properties": {
+                "BEGIN": {
+                    "required": true,
+                    "node": {
+                        "type": "string",
+                        "title": "BEGIN",
+                        "description": "The name of the Flow to begin on"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        {
+            "type": "record",
+            "keyType": {
                 "type": "string"
             },
-            {
-                "name": "NavigationFlow",
-                "type": "object",
-                "source": "src/index.ts",
-                "properties": {
-                    "startState": {
-                        "required": true,
-                        "node": {
-                            "type": "string",
-                            "title": "NavigationFlow.startState",
-                            "description": "The first state to kick off the state machine"
-                        }
+            "valueType": {
+                "type": "or",
+                "or": [
+                    {
+                        "type": "string"
                     },
-                    "onStart": {
-                        "required": false,
-                        "node": {
-                            "type": "or",
-                            "or": [
-                                {
-                                    "type": "ref",
-                                    "ref": "Expression",
-                                    "title": "NavigationFlow.onStart"
-                                },
-                                {
-                                    "name": "ExpressionObject",
-                                    "type": "object",
-                                    "source": "src/index.ts",
-                                    "properties": {
-                                        "exp": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "ref",
-                                                "ref": "Expression",
-                                                "title": "ExpressionObject.exp",
-                                                "description": "The expression to run"
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "title": "ExpressionObject",
-                                    "description": "An object with an expression in it"
-                                }
-                            ],
-                            "title": "NavigationFlow.onStart",
-                            "description": "An optional expression to run when this Flow starts"
-                        }
-                    },
-                    "onEnd": {
-                        "required": false,
-                        "node": {
-                            "type": "or",
-                            "or": [
-                                {
-                                    "type": "ref",
-                                    "ref": "Expression",
-                                    "title": "NavigationFlow.onEnd"
-                                },
-                                {
-                                    "name": "ExpressionObject",
-                                    "type": "object",
-                                    "source": "src/index.ts",
-                                    "properties": {
-                                        "exp": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "ref",
-                                                "ref": "Expression",
-                                                "title": "ExpressionObject.exp",
-                                                "description": "The expression to run"
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "title": "ExpressionObject",
-                                    "description": "An object with an expression in it"
-                                }
-                            ],
-                            "title": "NavigationFlow.onEnd",
-                            "description": "An optional expression to run when this Flow ends"
-                        }
-                    }
-                },
-                "additionalProperties": {
-                    "type": "or",
-                    "or": [
-                        {
-                            "type": "undefined"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "ref",
-                            "ref": "Expression"
-                        },
-                        {
-                            "name": "ExpressionObject",
-                            "type": "object",
-                            "source": "src/index.ts",
-                            "properties": {
-                                "exp": {
-                                    "required": false,
-                                    "node": {
-                                        "type": "ref",
-                                        "ref": "Expression",
-                                        "title": "ExpressionObject.exp",
-                                        "description": "The expression to run"
-                                    }
+                    {
+                        "name": "NavigationFlow",
+                        "type": "object",
+                        "source": "src/index.ts",
+                        "properties": {
+                            "startState": {
+                                "required": true,
+                                "node": {
+                                    "type": "string",
+                                    "title": "NavigationFlow.startState",
+                                    "description": "The first state to kick off the state machine"
                                 }
                             },
-                            "additionalProperties": false,
-                            "title": "ExpressionObject",
-                            "description": "An object with an expression in it"
+                            "onStart": {
+                                "required": false,
+                                "node": {
+                                    "type": "or",
+                                    "or": [
+                                        {
+                                            "type": "ref",
+                                            "ref": "Expression",
+                                            "title": "NavigationFlow.onStart"
+                                        },
+                                        {
+                                            "name": "ExpressionObject",
+                                            "type": "object",
+                                            "source": "src/index.ts",
+                                            "properties": {
+                                                "exp": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "ref",
+                                                        "ref": "Expression",
+                                                        "title": "ExpressionObject.exp",
+                                                        "description": "The expression to run"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "title": "ExpressionObject",
+                                            "description": "An object with an expression in it"
+                                        }
+                                    ],
+                                    "title": "NavigationFlow.onStart",
+                                    "description": "An optional expression to run when this Flow starts"
+                                }
+                            },
+                            "onEnd": {
+                                "required": false,
+                                "node": {
+                                    "type": "or",
+                                    "or": [
+                                        {
+                                            "type": "ref",
+                                            "ref": "Expression",
+                                            "title": "NavigationFlow.onEnd"
+                                        },
+                                        {
+                                            "name": "ExpressionObject",
+                                            "type": "object",
+                                            "source": "src/index.ts",
+                                            "properties": {
+                                                "exp": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "ref",
+                                                        "ref": "Expression",
+                                                        "title": "ExpressionObject.exp",
+                                                        "description": "The expression to run"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "title": "ExpressionObject",
+                                            "description": "An object with an expression in it"
+                                        }
+                                    ],
+                                    "title": "NavigationFlow.onEnd",
+                                    "description": "An optional expression to run when this Flow ends"
+                                }
+                            }
                         },
-                        {
-                            "name": "NavigationFlowState",
-                            "source": "src/index.ts",
+                        "additionalProperties": {
                             "type": "or",
                             "or": [
                                 {
-                                    "name": "NavigationFlowViewState",
-                                    "type": "object",
-                                    "source": "src/index.ts",
-                                    "properties": {
-                                        "_comment": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "CommentBase._comment",
-                                                "description": "Add comments that will not be processing, but are useful for code explanation"
-                                            }
-                                        },
-                                        "state_type": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "const": "VIEW",
-                                                "title": "NavigationBaseState.state_type",
-                                                "description": "A property to determine the type of state this is"
-                                            }
-                                        },
-                                        "onStart": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onStart"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
-                                                    }
-                                                ],
-                                                "title": "NavigationBaseState.onStart",
-                                                "description": "An optional expression to run when this view renders"
-                                            }
-                                        },
-                                        "onEnd": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onEnd"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
-                                                    }
-                                                ],
-                                                "title": "NavigationBaseState.onEnd",
-                                                "description": "An optional expression to run before view transition"
-                                            }
-                                        },
-                                        "exp": {
-                                            "required": false,
-                                            "node": {
-                                                "title": "NavigationBaseState.exp",
-                                                "type": "never"
-                                            }
-                                        },
-                                        "transitions": {
-                                            "required": true,
-                                            "node": {
-                                                "name": "NavigationFlowTransition",
-                                                "source": "src/index.ts",
-                                                "type": "record",
-                                                "keyType": {
-                                                    "type": "string"
-                                                },
-                                                "valueType": {
-                                                    "type": "string"
-                                                },
-                                                "title": "NavigationFlowTransitionableState.transitions",
-                                                "description": "A mapping of transition-name to FlowState name"
-                                            }
-                                        },
-                                        "ref": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "NavigationFlowViewState.ref",
-                                                "description": "An id corresponding to a view from the 'views' array"
-                                            }
-                                        },
-                                        "attributes": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "object",
-                                                "properties": {},
-                                                "additionalProperties": {
-                                                    "type": "any"
-                                                },
-                                                "title": "NavigationFlowViewState.attributes",
-                                                "description": "View meta-properties"
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "title": "NavigationFlowViewState",
-                                    "description": "A state representing a view"
+                                    "type": "undefined"
                                 },
                                 {
-                                    "name": "NavigationFlowEndState",
-                                    "type": "object",
-                                    "source": "src/index.ts",
-                                    "properties": {
-                                        "_comment": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "CommentBase._comment",
-                                                "description": "Add comments that will not be processing, but are useful for code explanation"
-                                            }
-                                        },
-                                        "state_type": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "const": "END",
-                                                "title": "NavigationBaseState.state_type",
-                                                "description": "A property to determine the type of state this is"
-                                            }
-                                        },
-                                        "onStart": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onStart"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
-                                                    }
-                                                ],
-                                                "title": "NavigationBaseState.onStart",
-                                                "description": "An optional expression to run when this view renders"
-                                            }
-                                        },
-                                        "onEnd": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onEnd"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
-                                                    }
-                                                ],
-                                                "title": "NavigationBaseState.onEnd",
-                                                "description": "An optional expression to run before view transition"
-                                            }
-                                        },
-                                        "exp": {
-                                            "required": false,
-                                            "node": {
-                                                "title": "NavigationBaseState.exp",
-                                                "type": "never"
-                                            }
-                                        },
-                                        "outcome": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "NavigationFlowEndState.outcome",
-                                                "description": "A description of _how_ the flow ended.\nIf this is a flow started from another flow, the outcome determines the flow transition"
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "title": "NavigationFlowEndState",
-                                    "description": "An END state of the flow."
+                                    "type": "string"
                                 },
                                 {
-                                    "name": "NavigationFlowFlowState",
-                                    "type": "object",
-                                    "source": "src/index.ts",
-                                    "properties": {
-                                        "_comment": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "CommentBase._comment",
-                                                "description": "Add comments that will not be processing, but are useful for code explanation"
-                                            }
-                                        },
-                                        "state_type": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "const": "FLOW",
-                                                "title": "NavigationBaseState.state_type",
-                                                "description": "A property to determine the type of state this is"
-                                            }
-                                        },
-                                        "onStart": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onStart"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
-                                                    }
-                                                ],
-                                                "title": "NavigationBaseState.onStart",
-                                                "description": "An optional expression to run when this view renders"
-                                            }
-                                        },
-                                        "onEnd": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onEnd"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
-                                                    }
-                                                ],
-                                                "title": "NavigationBaseState.onEnd",
-                                                "description": "An optional expression to run before view transition"
-                                            }
-                                        },
-                                        "exp": {
-                                            "required": false,
-                                            "node": {
-                                                "title": "NavigationBaseState.exp",
-                                                "type": "never"
-                                            }
-                                        },
-                                        "transitions": {
-                                            "required": true,
-                                            "node": {
-                                                "name": "NavigationFlowTransition",
-                                                "source": "src/index.ts",
-                                                "type": "record",
-                                                "keyType": {
-                                                    "type": "string"
-                                                },
-                                                "valueType": {
-                                                    "type": "string"
-                                                },
-                                                "title": "NavigationFlowTransitionableState.transitions",
-                                                "description": "A mapping of transition-name to FlowState name"
-                                            }
-                                        },
-                                        "ref": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "NavigationFlowFlowState.ref",
-                                                "description": "A reference to a FLOW id state to run"
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "title": "NavigationFlowFlowState"
+                                    "type": "ref",
+                                    "ref": "Expression"
                                 },
                                 {
-                                    "name": "NavigationFlowActionState",
+                                    "name": "ExpressionObject",
                                     "type": "object",
                                     "source": "src/index.ts",
                                     "properties": {
-                                        "_comment": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "CommentBase._comment",
-                                                "description": "Add comments that will not be processing, but are useful for code explanation"
-                                            }
-                                        },
-                                        "state_type": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "const": "ACTION",
-                                                "title": "NavigationBaseState.state_type",
-                                                "description": "A property to determine the type of state this is"
-                                            }
-                                        },
-                                        "onStart": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onStart"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
-                                                    }
-                                                ],
-                                                "title": "NavigationBaseState.onStart",
-                                                "description": "An optional expression to run when this view renders"
-                                            }
-                                        },
-                                        "onEnd": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onEnd"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
-                                                    }
-                                                ],
-                                                "title": "NavigationBaseState.onEnd",
-                                                "description": "An optional expression to run before view transition"
-                                            }
-                                        },
                                         "exp": {
-                                            "required": true,
+                                            "required": false,
                                             "node": {
                                                 "type": "ref",
                                                 "ref": "Expression",
-                                                "title": "NavigationFlowActionState.exp",
-                                                "description": "An expression to execute.\nThe return value determines the transition to take"
-                                            }
-                                        },
-                                        "transitions": {
-                                            "required": true,
-                                            "node": {
-                                                "name": "NavigationFlowTransition",
-                                                "source": "src/index.ts",
-                                                "type": "record",
-                                                "keyType": {
-                                                    "type": "string"
-                                                },
-                                                "valueType": {
-                                                    "type": "string"
-                                                },
-                                                "title": "NavigationFlowTransitionableState.transitions",
-                                                "description": "A mapping of transition-name to FlowState name"
+                                                "title": "ExpressionObject.exp",
+                                                "description": "The expression to run"
                                             }
                                         }
                                     },
                                     "additionalProperties": false,
-                                    "title": "NavigationFlowActionState",
-                                    "description": "Action states execute an expression to determine the next state to transition to"
+                                    "title": "ExpressionObject",
+                                    "description": "An object with an expression in it"
                                 },
                                 {
-                                    "name": "NavigationFlowExternalState",
-                                    "type": "object",
+                                    "name": "NavigationFlowState",
                                     "source": "src/index.ts",
-                                    "properties": {
-                                        "_comment": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "CommentBase._comment",
-                                                "description": "Add comments that will not be processing, but are useful for code explanation"
-                                            }
+                                    "type": "or",
+                                    "or": [
+                                        {
+                                            "name": "NavigationFlowViewState",
+                                            "type": "object",
+                                            "source": "src/index.ts",
+                                            "properties": {
+                                                "_comment": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "CommentBase._comment",
+                                                        "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                    }
+                                                },
+                                                "state_type": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "const": "VIEW",
+                                                        "title": "NavigationBaseState.state_type",
+                                                        "description": "A property to determine the type of state this is"
+                                                    }
+                                                },
+                                                "onStart": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onStart"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onStart",
+                                                        "description": "An optional expression to run when this view renders"
+                                                    }
+                                                },
+                                                "onEnd": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onEnd"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onEnd",
+                                                        "description": "An optional expression to run before view transition"
+                                                    }
+                                                },
+                                                "exp": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "title": "NavigationBaseState.exp",
+                                                        "type": "never"
+                                                    }
+                                                },
+                                                "transitions": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "name": "NavigationFlowTransition",
+                                                        "source": "src/index.ts",
+                                                        "type": "record",
+                                                        "keyType": {
+                                                            "type": "string"
+                                                        },
+                                                        "valueType": {
+                                                            "type": "string"
+                                                        },
+                                                        "title": "NavigationFlowTransitionableState.transitions",
+                                                        "description": "A mapping of transition-name to FlowState name"
+                                                    }
+                                                },
+                                                "ref": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "NavigationFlowViewState.ref",
+                                                        "description": "An id corresponding to a view from the 'views' array"
+                                                    }
+                                                },
+                                                "attributes": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "object",
+                                                        "properties": {},
+                                                        "additionalProperties": {
+                                                            "type": "any"
+                                                        },
+                                                        "title": "NavigationFlowViewState.attributes",
+                                                        "description": "View meta-properties"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "title": "NavigationFlowViewState",
+                                            "description": "A state representing a view"
                                         },
-                                        "state_type": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "const": "EXTERNAL",
-                                                "title": "NavigationBaseState.state_type",
-                                                "description": "A property to determine the type of state this is"
-                                            }
+                                        {
+                                            "name": "NavigationFlowEndState",
+                                            "type": "object",
+                                            "source": "src/index.ts",
+                                            "properties": {
+                                                "_comment": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "CommentBase._comment",
+                                                        "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                    }
+                                                },
+                                                "state_type": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "const": "END",
+                                                        "title": "NavigationBaseState.state_type",
+                                                        "description": "A property to determine the type of state this is"
+                                                    }
+                                                },
+                                                "onStart": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onStart"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onStart",
+                                                        "description": "An optional expression to run when this view renders"
+                                                    }
+                                                },
+                                                "onEnd": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onEnd"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onEnd",
+                                                        "description": "An optional expression to run before view transition"
+                                                    }
+                                                },
+                                                "exp": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "title": "NavigationBaseState.exp",
+                                                        "type": "never"
+                                                    }
+                                                },
+                                                "outcome": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "NavigationFlowEndState.outcome",
+                                                        "description": "A description of _how_ the flow ended.\nIf this is a flow started from another flow, the outcome determines the flow transition"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "title": "NavigationFlowEndState",
+                                            "description": "An END state of the flow."
                                         },
-                                        "onStart": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
+                                        {
+                                            "name": "NavigationFlowFlowState",
+                                            "type": "object",
+                                            "source": "src/index.ts",
+                                            "properties": {
+                                                "_comment": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "CommentBase._comment",
+                                                        "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                    }
+                                                },
+                                                "state_type": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "const": "FLOW",
+                                                        "title": "NavigationBaseState.state_type",
+                                                        "description": "A property to determine the type of state this is"
+                                                    }
+                                                },
+                                                "onStart": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onStart"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onStart",
+                                                        "description": "An optional expression to run when this view renders"
+                                                    }
+                                                },
+                                                "onEnd": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onEnd"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onEnd",
+                                                        "description": "An optional expression to run before view transition"
+                                                    }
+                                                },
+                                                "exp": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "title": "NavigationBaseState.exp",
+                                                        "type": "never"
+                                                    }
+                                                },
+                                                "transitions": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "name": "NavigationFlowTransition",
+                                                        "source": "src/index.ts",
+                                                        "type": "record",
+                                                        "keyType": {
+                                                            "type": "string"
+                                                        },
+                                                        "valueType": {
+                                                            "type": "string"
+                                                        },
+                                                        "title": "NavigationFlowTransitionableState.transitions",
+                                                        "description": "A mapping of transition-name to FlowState name"
+                                                    }
+                                                },
+                                                "ref": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "NavigationFlowFlowState.ref",
+                                                        "description": "A reference to a FLOW id state to run"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "title": "NavigationFlowFlowState"
+                                        },
+                                        {
+                                            "name": "NavigationFlowActionState",
+                                            "type": "object",
+                                            "source": "src/index.ts",
+                                            "properties": {
+                                                "_comment": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "CommentBase._comment",
+                                                        "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                    }
+                                                },
+                                                "state_type": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "const": "ACTION",
+                                                        "title": "NavigationBaseState.state_type",
+                                                        "description": "A property to determine the type of state this is"
+                                                    }
+                                                },
+                                                "onStart": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onStart"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onStart",
+                                                        "description": "An optional expression to run when this view renders"
+                                                    }
+                                                },
+                                                "onEnd": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onEnd"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onEnd",
+                                                        "description": "An optional expression to run before view transition"
+                                                    }
+                                                },
+                                                "exp": {
+                                                    "required": true,
+                                                    "node": {
                                                         "type": "ref",
                                                         "ref": "Expression",
-                                                        "title": "NavigationBaseState.onStart"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
-                                                        "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
-                                                        },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
+                                                        "title": "NavigationFlowActionState.exp",
+                                                        "description": "An expression to execute.\nThe return value determines the transition to take"
                                                     }
-                                                ],
-                                                "title": "NavigationBaseState.onStart",
-                                                "description": "An optional expression to run when this view renders"
-                                            }
-                                        },
-                                        "onEnd": {
-                                            "required": false,
-                                            "node": {
-                                                "type": "or",
-                                                "or": [
-                                                    {
-                                                        "type": "ref",
-                                                        "ref": "Expression",
-                                                        "title": "NavigationBaseState.onEnd"
-                                                    },
-                                                    {
-                                                        "name": "ExpressionObject",
-                                                        "type": "object",
+                                                },
+                                                "transitions": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "name": "NavigationFlowTransition",
                                                         "source": "src/index.ts",
-                                                        "properties": {
-                                                            "exp": {
-                                                                "required": false,
-                                                                "node": {
-                                                                    "type": "ref",
-                                                                    "ref": "Expression",
-                                                                    "title": "ExpressionObject.exp",
-                                                                    "description": "The expression to run"
-                                                                }
-                                                            }
+                                                        "type": "record",
+                                                        "keyType": {
+                                                            "type": "string"
                                                         },
-                                                        "additionalProperties": false,
-                                                        "title": "ExpressionObject",
-                                                        "description": "An object with an expression in it"
+                                                        "valueType": {
+                                                            "type": "string"
+                                                        },
+                                                        "title": "NavigationFlowTransitionableState.transitions",
+                                                        "description": "A mapping of transition-name to FlowState name"
                                                     }
-                                                ],
-                                                "title": "NavigationBaseState.onEnd",
-                                                "description": "An optional expression to run before view transition"
-                                            }
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "title": "NavigationFlowActionState",
+                                            "description": "Action states execute an expression to determine the next state to transition to"
                                         },
-                                        "exp": {
-                                            "required": false,
-                                            "node": {
-                                                "title": "NavigationBaseState.exp",
-                                                "type": "never"
-                                            }
-                                        },
-                                        "transitions": {
-                                            "required": true,
-                                            "node": {
-                                                "name": "NavigationFlowTransition",
-                                                "source": "src/index.ts",
-                                                "type": "record",
-                                                "keyType": {
-                                                    "type": "string"
+                                        {
+                                            "name": "NavigationFlowExternalState",
+                                            "type": "object",
+                                            "source": "src/index.ts",
+                                            "properties": {
+                                                "_comment": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "CommentBase._comment",
+                                                        "description": "Add comments that will not be processing, but are useful for code explanation"
+                                                    }
                                                 },
-                                                "valueType": {
-                                                    "type": "string"
+                                                "state_type": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "const": "EXTERNAL",
+                                                        "title": "NavigationBaseState.state_type",
+                                                        "description": "A property to determine the type of state this is"
+                                                    }
                                                 },
-                                                "title": "NavigationFlowTransitionableState.transitions",
-                                                "description": "A mapping of transition-name to FlowState name"
-                                            }
-                                        },
-                                        "ref": {
-                                            "required": true,
-                                            "node": {
-                                                "type": "string",
-                                                "title": "NavigationFlowExternalState.ref",
-                                                "description": "A reference for this external state"
-                                            }
+                                                "onStart": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onStart"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onStart",
+                                                        "description": "An optional expression to run when this view renders"
+                                                    }
+                                                },
+                                                "onEnd": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "type": "or",
+                                                        "or": [
+                                                            {
+                                                                "type": "ref",
+                                                                "ref": "Expression",
+                                                                "title": "NavigationBaseState.onEnd"
+                                                            },
+                                                            {
+                                                                "name": "ExpressionObject",
+                                                                "type": "object",
+                                                                "source": "src/index.ts",
+                                                                "properties": {
+                                                                    "exp": {
+                                                                        "required": false,
+                                                                        "node": {
+                                                                            "type": "ref",
+                                                                            "ref": "Expression",
+                                                                            "title": "ExpressionObject.exp",
+                                                                            "description": "The expression to run"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false,
+                                                                "title": "ExpressionObject",
+                                                                "description": "An object with an expression in it"
+                                                            }
+                                                        ],
+                                                        "title": "NavigationBaseState.onEnd",
+                                                        "description": "An optional expression to run before view transition"
+                                                    }
+                                                },
+                                                "exp": {
+                                                    "required": false,
+                                                    "node": {
+                                                        "title": "NavigationBaseState.exp",
+                                                        "type": "never"
+                                                    }
+                                                },
+                                                "transitions": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "name": "NavigationFlowTransition",
+                                                        "source": "src/index.ts",
+                                                        "type": "record",
+                                                        "keyType": {
+                                                            "type": "string"
+                                                        },
+                                                        "valueType": {
+                                                            "type": "string"
+                                                        },
+                                                        "title": "NavigationFlowTransitionableState.transitions",
+                                                        "description": "A mapping of transition-name to FlowState name"
+                                                    }
+                                                },
+                                                "ref": {
+                                                    "required": true,
+                                                    "node": {
+                                                        "type": "string",
+                                                        "title": "NavigationFlowExternalState.ref",
+                                                        "description": "A reference for this external state"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "title": "NavigationFlowExternalState",
+                                            "description": "External Flow states represent states in the FSM that can't be resolved internally in Player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
                                         }
-                                    },
-                                    "additionalProperties": false,
-                                    "title": "NavigationFlowExternalState",
-                                    "description": "External Flow states represent states in the FSM that can't be resolved internally in the player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
+                                    ],
+                                    "title": "NavigationFlowState"
                                 }
-                            ],
-                            "title": "NavigationFlowState"
-                        }
-                    ]
-                },
-                "title": "NavigationFlow",
-                "description": "A state machine in the navigation"
+                            ]
+                        },
+                        "title": "NavigationFlow",
+                        "description": "A state machine in the navigation"
+                    }
+                ]
             }
-        ]
-    },
+        }
+    ],
     "title": "Navigation",
     "description": "The navigation section of the flow describes a State Machine for the user."
 }

--- a/common/static_xlrs/core/xlr/NavigationFlow.json
+++ b/common/static_xlrs/core/xlr/NavigationFlow.json
@@ -734,7 +734,7 @@
                         },
                         "additionalProperties": false,
                         "title": "NavigationFlowExternalState",
-                        "description": "External Flow states represent states in the FSM that can't be resolved internally in the player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
+                        "description": "External Flow states represent states in the FSM that can't be resolved internally in Player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
                     }
                 ],
                 "title": "NavigationFlowState"

--- a/common/static_xlrs/core/xlr/NavigationFlowExternalState.json
+++ b/common/static_xlrs/core/xlr/NavigationFlowExternalState.json
@@ -122,5 +122,5 @@
     },
     "additionalProperties": false,
     "title": "NavigationFlowExternalState",
-    "description": "External Flow states represent states in the FSM that can't be resolved internally in the player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
+    "description": "External Flow states represent states in the FSM that can't be resolved internally in Player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
 }

--- a/common/static_xlrs/core/xlr/NavigationFlowState.json
+++ b/common/static_xlrs/core/xlr/NavigationFlowState.json
@@ -620,7 +620,7 @@
             },
             "additionalProperties": false,
             "title": "NavigationFlowExternalState",
-            "description": "External Flow states represent states in the FSM that can't be resolved internally in the player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
+            "description": "External Flow states represent states in the FSM that can't be resolved internally in Player.\nThe flow will wait for the embedded application to manage moving to the next state via a transition"
         }
     ],
     "title": "NavigationFlowState"

--- a/common/static_xlrs/core/xlr/Templatable.json
+++ b/common/static_xlrs/core/xlr/Templatable.json
@@ -12,14 +12,6 @@
                     "type": "object",
                     "source": "src/index.ts",
                     "properties": {
-                        "dynamic": {
-                            "required": false,
-                            "node": {
-                                "type": "boolean",
-                                "title": "Template.dynamic",
-                                "description": "should the template be recomputed when data changes"
-                            }
-                        },
                         "data": {
                             "required": true,
                             "node": {
@@ -36,6 +28,14 @@
                                 "ref": "ValueType",
                                 "title": "Template.value",
                                 "description": "The template to iterate over using each value in the supplied template data.\nAny reference to _index_ is replaced with the current iteration index."
+                            }
+                        },
+                        "dynamic": {
+                            "required": false,
+                            "node": {
+                                "type": "boolean",
+                                "title": "Template.dynamic",
+                                "description": "should the template be recomputed when data changes"
                             }
                         },
                         "output": {

--- a/common/static_xlrs/core/xlr/Template.json
+++ b/common/static_xlrs/core/xlr/Template.json
@@ -3,14 +3,6 @@
     "type": "object",
     "source": "src/index.ts",
     "properties": {
-        "dynamic": {
-            "required": false,
-            "node": {
-                "type": "boolean",
-                "title": "Template.dynamic",
-                "description": "should the template be recomputed when data changes"
-            }
-        },
         "data": {
             "required": true,
             "node": {
@@ -27,6 +19,14 @@
                 "ref": "ValueType",
                 "title": "Template.value",
                 "description": "The template to iterate over using each value in the supplied template data.\nAny reference to _index_ is replaced with the current iteration index."
+            }
+        },
+        "dynamic": {
+            "required": false,
+            "node": {
+                "type": "boolean",
+                "title": "Template.dynamic",
+                "description": "should the template be recomputed when data changes"
             }
         },
         "output": {

--- a/common/static_xlrs/core/xlr/View.json
+++ b/common/static_xlrs/core/xlr/View.json
@@ -1,143 +1,162 @@
 {
     "name": "View",
     "source": "src/index.ts",
-    "type": "and",
-    "and": [
-        {
+    "type": "conditional",
+    "check": {
+        "left": {
+            "type": "unknown"
+        },
+        "right": {
+            "type": "ref",
+            "ref": "Asset",
+            "property": "validation"
+        }
+    },
+    "value": {
+        "true": {
+            "type": "and",
+            "and": [
+                {
+                    "type": "ref",
+                    "ref": "T"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "validation": {
+                            "required": false,
+                            "node": {
+                                "type": "array",
+                                "elementType": {
+                                    "name": "CrossfieldReference",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "required": true,
+                                            "node": {
+                                                "type": "string",
+                                                "title": "Reference.type",
+                                                "description": "The name of the referenced validation type\nThis will be used to lookup the proper handler"
+                                            }
+                                        },
+                                        "message": {
+                                            "required": false,
+                                            "node": {
+                                                "type": "string",
+                                                "title": "Reference.message",
+                                                "description": "An optional means of overriding the default message if the validation is triggered"
+                                            }
+                                        },
+                                        "severity": {
+                                            "required": false,
+                                            "node": {
+                                                "name": "Severity",
+                                                "type": "or",
+                                                "or": [
+                                                    {
+                                                        "type": "string",
+                                                        "const": "error",
+                                                        "title": "Severity"
+                                                    },
+                                                    {
+                                                        "type": "string",
+                                                        "const": "warning",
+                                                        "title": "Severity"
+                                                    }
+                                                ],
+                                                "title": "Reference.severity",
+                                                "description": "An optional means of overriding the default severity of the validation if triggered"
+                                            }
+                                        },
+                                        "trigger": {
+                                            "required": false,
+                                            "node": {
+                                                "name": "Trigger",
+                                                "type": "or",
+                                                "or": [
+                                                    {
+                                                        "type": "string",
+                                                        "const": "navigation",
+                                                        "title": "Trigger"
+                                                    },
+                                                    {
+                                                        "type": "string",
+                                                        "const": "change",
+                                                        "title": "Trigger"
+                                                    },
+                                                    {
+                                                        "type": "string",
+                                                        "const": "load",
+                                                        "title": "Trigger"
+                                                    }
+                                                ],
+                                                "title": "Reference.trigger",
+                                                "description": "When to run this particular validation"
+                                            }
+                                        },
+                                        "dataTarget": {
+                                            "required": false,
+                                            "node": {
+                                                "type": "never",
+                                                "title": "CrossfieldReference.dataTarget",
+                                                "description": "Cross-field references and validation must run against the default (deformatted) value"
+                                            }
+                                        },
+                                        "displayTarget": {
+                                            "required": false,
+                                            "node": {
+                                                "name": "DisplayTarget",
+                                                "type": "or",
+                                                "or": [
+                                                    {
+                                                        "type": "string",
+                                                        "const": "page",
+                                                        "title": "DisplayTarget"
+                                                    },
+                                                    {
+                                                        "type": "string",
+                                                        "const": "section",
+                                                        "title": "DisplayTarget"
+                                                    },
+                                                    {
+                                                        "type": "string",
+                                                        "const": "field",
+                                                        "title": "DisplayTarget"
+                                                    }
+                                                ],
+                                                "title": "Reference.displayTarget",
+                                                "description": "Where the error should be displayed"
+                                            }
+                                        },
+                                        "ref": {
+                                            "required": false,
+                                            "node": {
+                                                "type": "ref",
+                                                "ref": "Binding",
+                                                "title": "CrossfieldReference.ref",
+                                                "description": "The binding to associate this validation with"
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": {
+                                        "type": "unknown"
+                                    },
+                                    "title": "CrossfieldReference"
+                                },
+                                "title": "validation",
+                                "description": "Each view can optionally supply a list of validations to run against a particular view"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "false": {
             "type": "ref",
             "ref": "T"
-        },
-        {
-            "type": "object",
-            "properties": {
-                "validation": {
-                    "required": false,
-                    "node": {
-                        "type": "array",
-                        "elementType": {
-                            "name": "CrossfieldReference",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "required": true,
-                                    "node": {
-                                        "type": "string",
-                                        "title": "Reference.type",
-                                        "description": "The name of the referenced validation type\nThis will be used to lookup the proper handler"
-                                    }
-                                },
-                                "message": {
-                                    "required": false,
-                                    "node": {
-                                        "type": "string",
-                                        "title": "Reference.message",
-                                        "description": "An optional means of overriding the default message if the validation is triggered"
-                                    }
-                                },
-                                "severity": {
-                                    "required": false,
-                                    "node": {
-                                        "name": "Severity",
-                                        "type": "or",
-                                        "or": [
-                                            {
-                                                "type": "string",
-                                                "const": "error",
-                                                "title": "Severity"
-                                            },
-                                            {
-                                                "type": "string",
-                                                "const": "warning",
-                                                "title": "Severity"
-                                            }
-                                        ],
-                                        "title": "Reference.severity",
-                                        "description": "An optional means of overriding the default severity of the validation if triggered"
-                                    }
-                                },
-                                "trigger": {
-                                    "required": false,
-                                    "node": {
-                                        "name": "Trigger",
-                                        "type": "or",
-                                        "or": [
-                                            {
-                                                "type": "string",
-                                                "const": "navigation",
-                                                "title": "Trigger"
-                                            },
-                                            {
-                                                "type": "string",
-                                                "const": "change",
-                                                "title": "Trigger"
-                                            },
-                                            {
-                                                "type": "string",
-                                                "const": "load",
-                                                "title": "Trigger"
-                                            }
-                                        ],
-                                        "title": "Reference.trigger",
-                                        "description": "When to run this particular validation"
-                                    }
-                                },
-                                "dataTarget": {
-                                    "required": false,
-                                    "node": {
-                                        "type": "never",
-                                        "title": "CrossfieldReference.dataTarget",
-                                        "description": "Cross-field references and validation must run against the default (deformatted) value"
-                                    }
-                                },
-                                "displayTarget": {
-                                    "required": false,
-                                    "node": {
-                                        "name": "DisplayTarget",
-                                        "type": "or",
-                                        "or": [
-                                            {
-                                                "type": "string",
-                                                "const": "page",
-                                                "title": "DisplayTarget"
-                                            },
-                                            {
-                                                "type": "string",
-                                                "const": "section",
-                                                "title": "DisplayTarget"
-                                            },
-                                            {
-                                                "type": "string",
-                                                "const": "field",
-                                                "title": "DisplayTarget"
-                                            }
-                                        ],
-                                        "title": "Reference.displayTarget",
-                                        "description": "Where the error should be displayed"
-                                    }
-                                },
-                                "ref": {
-                                    "required": false,
-                                    "node": {
-                                        "type": "ref",
-                                        "ref": "Binding",
-                                        "title": "CrossfieldReference.ref",
-                                        "description": "The binding to associate this validation with"
-                                    }
-                                }
-                            },
-                            "additionalProperties": {
-                                "type": "unknown"
-                            },
-                            "title": "CrossfieldReference"
-                        },
-                        "title": "validation",
-                        "description": "Each view can optionally supply a list of validations to run against a particular view"
-                    }
-                }
-            },
-            "additionalProperties": false
         }
-    ],
+    },
     "title": "View",
     "genericTokens": [
         {

--- a/common/static_xlrs/core/xlr/index.d.ts
+++ b/common/static_xlrs/core/xlr/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@player-tools/static-xlrs/static_xlrs/core/xlr/manifest';

--- a/common/static_xlrs/core/xlr/manifest.js
+++ b/common/static_xlrs/core/xlr/manifest.js
@@ -1,36 +1,36 @@
-import Asset from './Asset.json'
-import AssetBinding from './AssetBinding.json'
-import SwitchCase from './SwitchCase.json'
-import Switch from './Switch.json'
-import AssetWrapper from './AssetWrapper.json'
-import AssetWrapperOrSwitch from './AssetWrapperOrSwitch.json'
-import AssetSwitch from './AssetSwitch.json'
-import StaticSwitch from './StaticSwitch.json'
-import DynamicSwitch from './DynamicSwitch.json'
-import Expression from './Expression.json'
-import ExpressionRef from './ExpressionRef.json'
-import Binding from './Binding.json'
-import BindingRef from './BindingRef.json'
-import DataModel from './DataModel.json'
-import Navigation from './Navigation.json'
-import ExpressionObject from './ExpressionObject.json'
-import NavigationFlow from './NavigationFlow.json'
-import NavigationFlowTransition from './NavigationFlowTransition.json'
-import NavigationBaseState from './NavigationBaseState.json'
-import NavigationFlowTransitionableState from './NavigationFlowTransitionableState.json'
-import NavigationFlowViewState from './NavigationFlowViewState.json'
-import NavigationFlowEndState from './NavigationFlowEndState.json'
-import NavigationFlowActionState from './NavigationFlowActionState.json'
-import NavigationFlowExternalState from './NavigationFlowExternalState.json'
-import NavigationFlowFlowState from './NavigationFlowFlowState.json'
-import NavigationFlowState from './NavigationFlowState.json'
-import FlowResult from './FlowResult.json'
-import Templatable from './Templatable.json'
-import Template from './Template.json'
-import View from './View.json'
-import Flow from './Flow.json'
+const Asset = require( './Asset.json')
+const AssetBinding = require( './AssetBinding.json')
+const SwitchCase = require( './SwitchCase.json')
+const Switch = require( './Switch.json')
+const AssetWrapper = require( './AssetWrapper.json')
+const AssetWrapperOrSwitch = require( './AssetWrapperOrSwitch.json')
+const AssetSwitch = require( './AssetSwitch.json')
+const StaticSwitch = require( './StaticSwitch.json')
+const DynamicSwitch = require( './DynamicSwitch.json')
+const Expression = require( './Expression.json')
+const ExpressionRef = require( './ExpressionRef.json')
+const Binding = require( './Binding.json')
+const BindingRef = require( './BindingRef.json')
+const DataModel = require( './DataModel.json')
+const Navigation = require( './Navigation.json')
+const ExpressionObject = require( './ExpressionObject.json')
+const NavigationFlow = require( './NavigationFlow.json')
+const NavigationFlowTransition = require( './NavigationFlowTransition.json')
+const NavigationBaseState = require( './NavigationBaseState.json')
+const NavigationFlowTransitionableState = require( './NavigationFlowTransitionableState.json')
+const NavigationFlowViewState = require( './NavigationFlowViewState.json')
+const NavigationFlowEndState = require( './NavigationFlowEndState.json')
+const NavigationFlowActionState = require( './NavigationFlowActionState.json')
+const NavigationFlowExternalState = require( './NavigationFlowExternalState.json')
+const NavigationFlowFlowState = require( './NavigationFlowFlowState.json')
+const NavigationFlowState = require( './NavigationFlowState.json')
+const FlowResult = require( './FlowResult.json')
+const Templatable = require( './Templatable.json')
+const Template = require( './Template.json')
+const View = require( './View.json')
+const Flow = require( './Flow.json')
 
-export default {
+module.exports = {
   "pluginName": "Types",
   "capabilities": {
     "Types":[Asset,AssetBinding,SwitchCase,Switch,AssetWrapper,AssetWrapperOrSwitch,AssetSwitch,StaticSwitch,DynamicSwitch,Expression,ExpressionRef,Binding,BindingRef,DataModel,Navigation,ExpressionObject,NavigationFlow,NavigationFlowTransition,NavigationBaseState,NavigationFlowTransitionableState,NavigationFlowViewState,NavigationFlowEndState,NavigationFlowActionState,NavigationFlowExternalState,NavigationFlowFlowState,NavigationFlowState,FlowResult,Templatable,Template,View,Flow],

--- a/common/static_xlrs/plugin/xlr/ActionAsset.json
+++ b/common/static_xlrs/plugin/xlr/ActionAsset.json
@@ -1,25 +1,8 @@
 {
     "name": "ActionAsset",
     "type": "object",
-    "source": "/Users/kreddy8/dev/player/reference-assets/action/dist/types.d.ts",
+    "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/action/types.ts",
     "properties": {
-        "id": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "title": "Asset.id",
-                "description": "Each asset requires a unique id per view"
-            }
-        },
-        "type": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "const": "action",
-                "title": "Asset.type",
-                "description": "The asset type determines the semantics of how a user interacts with a page"
-            }
-        },
         "value": {
             "required": false,
             "node": {
@@ -69,7 +52,7 @@
                         "required": false,
                         "node": {
                             "name": "BeaconDataType",
-                            "source": "/Users/kreddy8/dev/player/plugins/beacon/dist/beacon.d.ts",
+                            "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/node_modules/@player-ui/beacon-plugin/dist/index.d.ts",
                             "type": "or",
                             "or": [
                                 {
@@ -106,9 +89,7 @@
             }
         }
     },
-    "additionalProperties": {
-        "type": "unknown"
-    },
+    "additionalProperties": false,
     "title": "ActionAsset",
     "description": "User actions can be represented in several places.\nEach view typically has one or more actions that allow the user to navigate away from that view.\nIn addition, several asset types can have actions that apply to that asset only.",
     "genericTokens": [
@@ -123,5 +104,15 @@
                 "ref": "Asset"
             }
         }
-    ]
+    ],
+    "extends": {
+        "type": "ref",
+        "ref": "Asset<'action'>",
+        "genericArguments": [
+            {
+                "type": "string",
+                "const": "action"
+            }
+        ]
+    }
 }

--- a/common/static_xlrs/plugin/xlr/CollectionAsset.json
+++ b/common/static_xlrs/plugin/xlr/CollectionAsset.json
@@ -1,27 +1,19 @@
 {
     "name": "CollectionAsset",
     "type": "object",
-    "source": "/Users/kreddy8/dev/player/reference-assets/collection/dist/types.d.ts",
+    "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/collection/types.ts",
     "properties": {
-        "id": {
-            "required": true,
+        "label": {
+            "required": false,
             "node": {
-                "type": "string",
-                "title": "Asset.id",
-                "description": "Each asset requires a unique id per view"
-            }
-        },
-        "type": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "const": "collection",
-                "title": "Asset.type",
-                "description": "The asset type determines the semantics of how a user interacts with a page"
+                "type": "ref",
+                "ref": "AssetWrapper",
+                "title": "CollectionAsset.label",
+                "description": "An optional label to title the collection"
             }
         },
         "values": {
-            "required": true,
+            "required": false,
             "node": {
                 "type": "array",
                 "elementType": {
@@ -33,8 +25,16 @@
             }
         }
     },
-    "additionalProperties": {
-        "type": "unknown"
-    },
-    "title": "CollectionAsset"
+    "additionalProperties": false,
+    "title": "CollectionAsset",
+    "extends": {
+        "type": "ref",
+        "ref": "Asset<'collection'>",
+        "genericArguments": [
+            {
+                "type": "string",
+                "const": "collection"
+            }
+        ]
+    }
 }

--- a/common/static_xlrs/plugin/xlr/InfoAsset.json
+++ b/common/static_xlrs/plugin/xlr/InfoAsset.json
@@ -1,25 +1,8 @@
 {
     "name": "InfoAsset",
     "type": "object",
-    "source": "/Users/kreddy8/dev/player/reference-assets/info/dist/types.d.ts",
+    "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/info/types.ts",
     "properties": {
-        "id": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "title": "Asset.id",
-                "description": "Each asset requires a unique id per view"
-            }
-        },
-        "type": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "const": "info",
-                "title": "Asset.type",
-                "description": "The asset type determines the semantics of how a user interacts with a page"
-            }
-        },
         "title": {
             "required": false,
             "node": {
@@ -60,8 +43,16 @@
             }
         }
     },
-    "additionalProperties": {
-        "type": "unknown"
-    },
-    "title": "InfoAsset"
+    "additionalProperties": false,
+    "title": "InfoAsset",
+    "extends": {
+        "type": "ref",
+        "ref": "Asset<'info'>",
+        "genericArguments": [
+            {
+                "type": "string",
+                "const": "info"
+            }
+        ]
+    }
 }

--- a/common/static_xlrs/plugin/xlr/InputAsset.json
+++ b/common/static_xlrs/plugin/xlr/InputAsset.json
@@ -1,25 +1,8 @@
 {
     "name": "InputAsset",
     "type": "object",
-    "source": "/Users/kreddy8/dev/player/reference-assets/input/dist/types.d.ts",
+    "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/input/types.ts",
     "properties": {
-        "id": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "title": "Asset.id",
-                "description": "Each asset requires a unique id per view"
-            }
-        },
-        "type": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "const": "input",
-                "title": "Asset.type",
-                "description": "The asset type determines the semantics of how a user interacts with a page"
-            }
-        },
         "label": {
             "required": false,
             "node": {
@@ -33,6 +16,21 @@
                 ],
                 "title": "InputAsset.label",
                 "description": "Asset container for a field label."
+            }
+        },
+        "note": {
+            "required": false,
+            "node": {
+                "type": "ref",
+                "ref": "AssetWrapper<AnyTextAsset>",
+                "genericArguments": [
+                    {
+                        "type": "ref",
+                        "ref": "AnyTextAsset"
+                    }
+                ],
+                "title": "InputAsset.note",
+                "description": "Asset container for a note."
             }
         },
         "binding": {
@@ -53,7 +51,7 @@
                         "required": false,
                         "node": {
                             "name": "BeaconDataType",
-                            "source": "/Users/kreddy8/dev/player/plugins/beacon/dist/beacon.d.ts",
+                            "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/node_modules/@player-ui/beacon-plugin/dist/index.d.ts",
                             "type": "or",
                             "or": [
                                 {
@@ -82,9 +80,7 @@
             }
         }
     },
-    "additionalProperties": {
-        "type": "unknown"
-    },
+    "additionalProperties": false,
     "title": "InputAsset",
     "description": "This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.\nPlayers can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.",
     "genericTokens": [
@@ -99,5 +95,15 @@
                 "ref": "Asset"
             }
         }
-    ]
+    ],
+    "extends": {
+        "type": "ref",
+        "ref": "Asset<'input'>",
+        "genericArguments": [
+            {
+                "type": "string",
+                "const": "input"
+            }
+        ]
+    }
 }

--- a/common/static_xlrs/plugin/xlr/TextAsset.json
+++ b/common/static_xlrs/plugin/xlr/TextAsset.json
@@ -1,25 +1,8 @@
 {
     "name": "TextAsset",
     "type": "object",
-    "source": "/Users/kreddy8/dev/player/reference-assets/text/dist/types.d.ts",
+    "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/text/types.ts",
     "properties": {
-        "id": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "title": "Asset.id",
-                "description": "Each asset requires a unique id per view"
-            }
-        },
-        "type": {
-            "required": true,
-            "node": {
-                "type": "string",
-                "const": "text",
-                "title": "Asset.type",
-                "description": "The asset type determines the semantics of how a user interacts with a page"
-            }
-        },
         "value": {
             "required": true,
             "node": {
@@ -34,13 +17,13 @@
                 "type": "array",
                 "elementType": {
                     "name": "TextModifier",
-                    "source": "/Users/kreddy8/dev/player/reference-assets/text/dist/types.d.ts",
+                    "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/text/types.ts",
                     "type": "or",
                     "or": [
                         {
                             "name": "BasicTextModifier",
                             "type": "object",
-                            "source": "/Users/kreddy8/dev/player/reference-assets/text/dist/types.d.ts",
+                            "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/text/types.ts",
                             "properties": {
                                 "type": {
                                     "required": true,
@@ -67,7 +50,7 @@
                         {
                             "name": "LinkModifier",
                             "type": "object",
-                            "source": "/Users/kreddy8/dev/player/reference-assets/text/dist/types.d.ts",
+                            "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/text/types.ts",
                             "properties": {
                                 "type": {
                                     "required": true,
@@ -127,8 +110,16 @@
             }
         }
     },
-    "additionalProperties": {
-        "type": "unknown"
-    },
-    "title": "TextAsset"
+    "additionalProperties": false,
+    "title": "TextAsset",
+    "extends": {
+        "type": "ref",
+        "ref": "Asset<'text'>",
+        "genericArguments": [
+            {
+                "type": "string",
+                "const": "text"
+            }
+        ]
+    }
 }

--- a/common/static_xlrs/plugin/xlr/index.d.ts
+++ b/common/static_xlrs/plugin/xlr/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@player-tools/static-xlrs/static_xlrs/plugin/xlr/manifest';

--- a/common/static_xlrs/plugin/xlr/manifest.js
+++ b/common/static_xlrs/plugin/xlr/manifest.js
@@ -1,12 +1,12 @@
-import InputAsset from './InputAsset.json'
-import TextAsset from './TextAsset.json'
-import ActionAsset from './ActionAsset.json'
-import InfoAsset from './InfoAsset.json'
-import CollectionAsset from './CollectionAsset.json'
-import TransformedAction from './TransformedAction.json'
-import TransformedInput from './TransformedInput.json'
+const InputAsset = require( './InputAsset.json')
+const TextAsset = require( './TextAsset.json')
+const ActionAsset = require( './ActionAsset.json')
+const InfoAsset = require( './InfoAsset.json')
+const CollectionAsset = require( './CollectionAsset.json')
+const TransformedAction = require( './TransformedAction.json')
+const TransformedInput = require( './TransformedInput.json')
 
-export default {
+module.exports = {
   "pluginName": "BaseAssetsPlugin",
   "capabilities": {
     "Assets":[InputAsset,TextAsset,ActionAsset,InfoAsset,CollectionAsset, TransformedAction, TransformedInput],

--- a/language/service/src/__tests__/__snapshots__/service.test.ts.snap
+++ b/language/service/src/__tests__/__snapshots__/service.test.ts.snap
@@ -3,6 +3,11 @@
 exports[`player language service completion basic object completions 1`] = `
 Array [
   Object {
+    "documentation": "Adds a comment for the given node",
+    "kind": 10,
+    "label": "_comment",
+  },
+  Object {
     "documentation": "The text to display",
     "kind": 10,
     "label": "value",
@@ -16,11 +21,6 @@ Array [
     "documentation": "Evaluate the given expression (or boolean) and if falsy, remove this node from the tree. This is re-computed for each change in the data-model",
     "kind": 10,
     "label": "applicability",
-  },
-  Object {
-    "documentation": "Adds a comment for the given node",
-    "kind": 10,
-    "label": "_comment",
   },
   Object {
     "documentation": "A list of templates to process for this node",

--- a/language/service/src/index.ts
+++ b/language/service/src/index.ts
@@ -47,6 +47,7 @@ export * from './utils';
 export * from './constants';
 export * from './types';
 export * from './parser';
+export * from './xlr/index';
 
 export interface PlayerLanguageServicePlugin {
   /** The name of the plugin */
@@ -184,7 +185,7 @@ export class PlayerLanguageService {
 
     const { node } = await this.getJSONPositionInfo(ctx, position);
 
-    const XLRInfo = await this.XLRService.getTypeInfoAtPosition(node);
+    const XLRInfo = this.XLRService.getTypeInfoAtPosition(node);
     if (!node || !XLRInfo) {
       return undefined;
     }

--- a/language/service/src/plugins/asset-wrapper-array-plugin.ts
+++ b/language/service/src/plugins/asset-wrapper-array-plugin.ts
@@ -57,9 +57,7 @@ export class AssetWrapperArrayPlugin implements PlayerLanguageServicePlugin {
               return;
             }
 
-            const xlrInfo = await service.XLRService.getTypeInfoAtPosition(
-              arrayNode
-            );
+            const xlrInfo = service.XLRService.getTypeInfoAtPosition(arrayNode);
             if (!xlrInfo) return;
 
             const isAssetWrapper = checkTypesForAssetWrapper(xlrInfo.nodes);

--- a/language/service/src/xlr/__tests__/__snapshots__/transform.test.ts.snap
+++ b/language/service/src/xlr/__tests__/__snapshots__/transform.test.ts.snap
@@ -35,6 +35,7 @@ Object {
         "description": "A text-like asset for the action's label",
         "genericArguments": Array [
           Object {
+            "genericArguments": undefined,
             "ref": "AnyAsset",
             "type": "ref",
           },
@@ -48,6 +49,7 @@ Object {
     "secondaryChildren": Object {
       "node": Object {
         "elementType": Object {
+          "genericArguments": undefined,
           "ref": "Asset",
           "type": "ref",
         },
@@ -187,6 +189,7 @@ Object {
     "type": "unknown",
   },
   "description": "Mock Asset for test",
+  "extends": undefined,
   "genericTokens": Array [
     Object {
       "constraints": Object {
@@ -215,6 +218,7 @@ Object {
         "description": "A text-like asset for the action's label",
         "genericArguments": Array [
           Object {
+            "genericArguments": undefined,
             "ref": "AnyAsset",
             "type": "ref",
           },
@@ -228,6 +232,7 @@ Object {
     "secondaryChildren": Object {
       "node": Object {
         "elementType": Object {
+          "genericArguments": undefined,
           "ref": "Asset",
           "type": "ref",
         },
@@ -239,6 +244,7 @@ Object {
       "node": Object {
         "description": "A list of templates to process for this node",
         "elementType": Object {
+          "genericArguments": undefined,
           "ref": "Template<Asset, \\"secondaryChildren\\">",
           "type": "ref",
         },
@@ -276,6 +282,7 @@ Object {
     "type": "unknown",
   },
   "description": "Mock Asset for test",
+  "extends": undefined,
   "genericTokens": Array [
     Object {
       "constraints": Object {
@@ -304,6 +311,7 @@ Object {
         "description": "A text-like asset for the action's label",
         "genericArguments": Array [
           Object {
+            "genericArguments": undefined,
             "ref": "AnyAsset",
             "type": "ref",
           },
@@ -317,6 +325,7 @@ Object {
     "secondaryChildren": Object {
       "node": Object {
         "elementType": Object {
+          "genericArguments": undefined,
           "ref": "Asset",
           "type": "ref",
         },
@@ -343,10 +352,12 @@ Object {
             "type": "string",
           },
           Object {
+            "genericArguments": undefined,
             "ref": "ExpressionRef",
             "type": "ref",
           },
           Object {
+            "genericArguments": undefined,
             "ref": "BindingRef",
             "type": "ref",
           },

--- a/language/service/src/xlr/__tests__/__snapshots__/transform.test.ts.snap
+++ b/language/service/src/xlr/__tests__/__snapshots__/transform.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     "type": "unknown",
   },
   "description": "Mock Asset for test",
+  "extends": undefined,
   "genericTokens": Array [
     Object {
       "constraints": Object {

--- a/language/service/src/xlr/__tests__/transform.test.ts
+++ b/language/service/src/xlr/__tests__/transform.test.ts
@@ -90,22 +90,18 @@ describe('Transform Tests', () => {
   });
 
   it('CommonProps Transform', () => {
-    applyCommonProps(MockAsset, 'Assets');
-    expect(MockAsset).toMatchSnapshot();
+    expect(applyCommonProps(MockAsset, 'Assets')).toMatchSnapshot();
   });
 
   it('AssetWrapperOrSwitch Transform', () => {
-    applyAssetWrapperOrSwitch(MockAsset, 'Assets');
-    expect(MockAsset).toMatchSnapshot();
+    expect(applyAssetWrapperOrSwitch(MockAsset, 'Assets')).toMatchSnapshot();
   });
 
   it('applyValueRefs Transform', () => {
-    applyValueRefs(MockAsset, 'Assets');
-    expect(MockAsset).toMatchSnapshot();
+    expect(applyValueRefs(MockAsset, 'Assets')).toMatchSnapshot();
   });
 
   it('applyTemplateProperty Transform', () => {
-    applyTemplateProperty(MockAsset, 'Assets');
-    expect(MockAsset).toMatchSnapshot();
+    expect(applyTemplateProperty(MockAsset, 'Assets')).toMatchSnapshot();
   });
 });

--- a/language/service/src/xlr/registry.ts
+++ b/language/service/src/xlr/registry.ts
@@ -5,7 +5,7 @@ import type { NamedType, NodeType } from '@player-tools/xlr';
 /**
  * Player specific implementation of a XLRs Registry
  */
-export class PlayerxlrRegistry extends BasicXLRRegistry {
+export class PlayerXLRRegistry extends BasicXLRRegistry {
   /** Keeps the mapping of how a type is referenced by Player to the underlying XLR */
   private registrationMap: Map<string, string | Array<string>>;
 
@@ -36,15 +36,15 @@ export class PlayerxlrRegistry extends BasicXLRRegistry {
 
   add(type: NamedType<NodeType>, plugin: string, capability: string): void {
     let registeredName = type.name;
-
-    // Figure out how the Asset/View will be referenced
+    // Figure out how the Asset/View will be referenced from the type argument that will fill in Asset
     if (
       (capability === 'Assets' || capability === 'Views') &&
       type.type === 'object' &&
-      type.properties?.type?.node?.type === 'string' &&
-      type.properties.type.node.const
+      type.extends?.genericArguments?.[0].type === 'string' &&
+      type.extends?.genericArguments?.[0].const
     ) {
-      registeredName = type.properties.type.node.const;
+      this.registrationMap.set(registeredName, type.name);
+      registeredName = type.extends?.genericArguments?.[0].const;
     }
 
     if (this.registrationMap.has(registeredName)) {

--- a/language/service/src/xlr/registry.ts
+++ b/language/service/src/xlr/registry.ts
@@ -40,11 +40,11 @@ export class PlayerXLRRegistry extends BasicXLRRegistry {
     if (
       (capability === 'Assets' || capability === 'Views') &&
       type.type === 'object' &&
-      type.extends?.genericArguments?.[0].type === 'string' &&
-      type.extends?.genericArguments?.[0].const
+      type.extends?.genericArguments?.[0]?.type === 'string' &&
+      type.extends?.genericArguments?.[0]?.const
     ) {
       this.registrationMap.set(registeredName, type.name);
-      registeredName = type.extends?.genericArguments?.[0].const;
+      registeredName = type.extends.genericArguments[0].const;
     }
 
     if (this.registrationMap.has(registeredName)) {

--- a/language/service/src/xlr/service.ts
+++ b/language/service/src/xlr/service.ts
@@ -1,9 +1,15 @@
 /* eslint-disable no-restricted-syntax */
-import { XLRSDK } from '@player-tools/xlr-sdk';
-import type { ArrayType, NodeType, ObjectType } from '@player-tools/xlr';
+import { simpleTransformGenerator, XLRSDK } from '@player-tools/xlr-sdk';
+import type {
+  ArrayType,
+  NamedType,
+  NodeType,
+  ObjectType,
+} from '@player-tools/xlr';
+import { computeEffectiveObject } from '@player-tools/xlr-utils';
 import type { ASTNode } from '../parser';
 import { mapFlowStateToType } from '../utils';
-import { PlayerxlrRegistry } from './registry';
+import { PlayerXLRRegistry } from './registry';
 
 export interface XLRContext {
   /** The name of the XLR at the provided position */
@@ -32,7 +38,7 @@ export class XLRService {
   public XLRSDK: XLRSDK;
 
   constructor() {
-    this.XLRSDK = new XLRSDK(new PlayerxlrRegistry());
+    this.XLRSDK = new XLRSDK(new PlayerXLRRegistry());
   }
 
   private walker(
@@ -97,9 +103,9 @@ export class XLRService {
     return undefined;
   }
 
-  public async getTypeInfoAtPosition(
+  public getTypeInfoAtPosition(
     node: ASTNode | undefined
-  ): Promise<XLRContext | undefined> {
+  ): XLRContext | undefined {
     if (!node) return;
 
     const pointer = node;

--- a/language/service/src/xlr/service.ts
+++ b/language/service/src/xlr/service.ts
@@ -1,12 +1,6 @@
 /* eslint-disable no-restricted-syntax */
-import { simpleTransformGenerator, XLRSDK } from '@player-tools/xlr-sdk';
-import type {
-  ArrayType,
-  NamedType,
-  NodeType,
-  ObjectType,
-} from '@player-tools/xlr';
-import { computeEffectiveObject } from '@player-tools/xlr-utils';
+import { XLRSDK } from '@player-tools/xlr-sdk';
+import type { ArrayType, NodeType, ObjectType } from '@player-tools/xlr';
 import type { ASTNode } from '../parser';
 import { mapFlowStateToType } from '../utils';
 import { PlayerXLRRegistry } from './registry';

--- a/xlr/converters/src/__tests__/__snapshots__/common-to-ts.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/common-to-ts.test.ts.snap
@@ -6,10 +6,7 @@ exports[`Type Exports Basic Type Conversion 1`] = `
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    type: \\"action\\";
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */

--- a/xlr/converters/src/__tests__/__snapshots__/common-to-ts.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/common-to-ts.test.ts.snap
@@ -24,3 +24,5 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'
     };
 }"
 `;
+
+exports[`Type Exports Template Type Conversion 1`] = `"export type BindingRef = \`{{\${string}}}\`;"`;

--- a/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
@@ -131,12 +131,10 @@ Array [
       "genericTokens": Array [
         Object {
           "constraints": Object {
-            "genericArguments": undefined,
             "ref": "Asset",
             "type": "ref",
           },
           "default": Object {
-            "genericArguments": undefined,
             "ref": "Asset",
             "type": "ref",
           },
@@ -159,7 +157,6 @@ Array [
             "description": "An expression to execute to determine if this case applies",
             "or": Array [
               Object {
-                "genericArguments": undefined,
                 "ref": "Expression",
                 "title": "SwitchCase.case",
                 "type": "ref",
@@ -321,12 +318,10 @@ Array [
                     "genericTokens": Array [
                       Object {
                         "constraints": Object {
-                          "genericArguments": undefined,
                           "ref": "Asset",
                           "type": "ref",
                         },
                         "default": Object {
-                          "genericArguments": undefined,
                           "ref": "Asset",
                           "type": "ref",
                         },
@@ -349,7 +344,6 @@ Array [
                           "description": "An expression to execute to determine if this case applies",
                           "or": Array [
                             Object {
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "SwitchCase.case",
                               "type": "ref",
@@ -373,12 +367,10 @@ Array [
                   "genericTokens": Array [
                     Object {
                       "constraints": Object {
-                        "genericArguments": undefined,
                         "ref": "Asset",
                         "type": "ref",
                       },
                       "default": Object {
-                        "genericArguments": undefined,
                         "ref": "Asset",
                         "type": "ref",
                       },
@@ -452,12 +444,10 @@ Array [
                     "genericTokens": Array [
                       Object {
                         "constraints": Object {
-                          "genericArguments": undefined,
                           "ref": "Asset",
                           "type": "ref",
                         },
                         "default": Object {
-                          "genericArguments": undefined,
                           "ref": "Asset",
                           "type": "ref",
                         },
@@ -480,7 +470,6 @@ Array [
                           "description": "An expression to execute to determine if this case applies",
                           "or": Array [
                             Object {
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "SwitchCase.case",
                               "type": "ref",
@@ -504,12 +493,10 @@ Array [
                   "genericTokens": Array [
                     Object {
                       "constraints": Object {
-                        "genericArguments": undefined,
                         "ref": "Asset",
                         "type": "ref",
                       },
                       "default": Object {
-                        "genericArguments": undefined,
                         "ref": "Asset",
                         "type": "ref",
                       },
@@ -581,12 +568,10 @@ Array [
         "genericTokens": Array [
           Object {
             "constraints": Object {
-              "genericArguments": undefined,
               "ref": "Asset",
               "type": "ref",
             },
             "default": Object {
-              "genericArguments": undefined,
               "ref": "Asset",
               "type": "ref",
             },
@@ -604,12 +589,10 @@ Array [
                 "genericTokens": Array [
                   Object {
                     "constraints": Object {
-                      "genericArguments": undefined,
                       "ref": "Asset",
                       "type": "ref",
                     },
                     "default": Object {
-                      "genericArguments": undefined,
                       "ref": "Asset",
                       "type": "ref",
                     },
@@ -632,7 +615,6 @@ Array [
                       "description": "An expression to execute to determine if this case applies",
                       "or": Array [
                         Object {
-                          "genericArguments": undefined,
                           "ref": "Expression",
                           "title": "SwitchCase.case",
                           "type": "ref",
@@ -656,12 +638,10 @@ Array [
               "genericTokens": Array [
                 Object {
                   "constraints": Object {
-                    "genericArguments": undefined,
                     "ref": "Asset",
                     "type": "ref",
                   },
                   "default": Object {
-                    "genericArguments": undefined,
                     "ref": "Asset",
                     "type": "ref",
                   },
@@ -685,12 +665,10 @@ Array [
         "genericTokens": Array [
           Object {
             "constraints": Object {
-              "genericArguments": undefined,
               "ref": "Asset",
               "type": "ref",
             },
             "default": Object {
-              "genericArguments": undefined,
               "ref": "Asset",
               "type": "ref",
             },
@@ -708,12 +686,10 @@ Array [
                 "genericTokens": Array [
                   Object {
                     "constraints": Object {
-                      "genericArguments": undefined,
                       "ref": "Asset",
                       "type": "ref",
                     },
                     "default": Object {
-                      "genericArguments": undefined,
                       "ref": "Asset",
                       "type": "ref",
                     },
@@ -736,7 +712,6 @@ Array [
                       "description": "An expression to execute to determine if this case applies",
                       "or": Array [
                         Object {
-                          "genericArguments": undefined,
                           "ref": "Expression",
                           "title": "SwitchCase.case",
                           "type": "ref",
@@ -760,12 +735,10 @@ Array [
               "genericTokens": Array [
                 Object {
                   "constraints": Object {
-                    "genericArguments": undefined,
                     "ref": "Asset",
                     "type": "ref",
                   },
                   "default": Object {
-                    "genericArguments": undefined,
                     "ref": "Asset",
                     "type": "ref",
                   },
@@ -794,12 +767,10 @@ Array [
     "genericTokens": Array [
       Object {
         "constraints": Object {
-          "genericArguments": undefined,
           "ref": "Asset",
           "type": "ref",
         },
         "default": Object {
-          "genericArguments": undefined,
           "ref": "Asset",
           "type": "ref",
         },
@@ -817,12 +788,10 @@ Array [
             "genericTokens": Array [
               Object {
                 "constraints": Object {
-                  "genericArguments": undefined,
                   "ref": "Asset",
                   "type": "ref",
                 },
                 "default": Object {
-                  "genericArguments": undefined,
                   "ref": "Asset",
                   "type": "ref",
                 },
@@ -845,7 +814,6 @@ Array [
                   "description": "An expression to execute to determine if this case applies",
                   "or": Array [
                     Object {
-                      "genericArguments": undefined,
                       "ref": "Expression",
                       "title": "SwitchCase.case",
                       "type": "ref",
@@ -869,12 +837,10 @@ Array [
           "genericTokens": Array [
             Object {
               "constraints": Object {
-                "genericArguments": undefined,
                 "ref": "Asset",
                 "type": "ref",
               },
               "default": Object {
-                "genericArguments": undefined,
                 "ref": "Asset",
                 "type": "ref",
               },
@@ -898,12 +864,10 @@ Array [
     "genericTokens": Array [
       Object {
         "constraints": Object {
-          "genericArguments": undefined,
           "ref": "Asset",
           "type": "ref",
         },
         "default": Object {
-          "genericArguments": undefined,
           "ref": "Asset",
           "type": "ref",
         },
@@ -921,12 +885,10 @@ Array [
             "genericTokens": Array [
               Object {
                 "constraints": Object {
-                  "genericArguments": undefined,
                   "ref": "Asset",
                   "type": "ref",
                 },
                 "default": Object {
-                  "genericArguments": undefined,
                   "ref": "Asset",
                   "type": "ref",
                 },
@@ -949,7 +911,6 @@ Array [
                   "description": "An expression to execute to determine if this case applies",
                   "or": Array [
                     Object {
-                      "genericArguments": undefined,
                       "ref": "Expression",
                       "title": "SwitchCase.case",
                       "type": "ref",
@@ -973,12 +934,10 @@ Array [
           "genericTokens": Array [
             Object {
               "constraints": Object {
-                "genericArguments": undefined,
                 "ref": "Asset",
                 "type": "ref",
               },
               "default": Object {
-                "genericArguments": undefined,
                 "ref": "Asset",
                 "type": "ref",
               },
@@ -1107,7 +1066,6 @@ If the expression is a composite, the last expression executed is the return val
                       "exp": Object {
                         "node": Object {
                           "description": "The expression to run",
-                          "genericArguments": undefined,
                           "ref": "Expression",
                           "title": "ExpressionObject.exp",
                           "type": "ref",
@@ -1176,7 +1134,6 @@ If the expression is a composite, the last expression executed is the return val
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1213,7 +1170,6 @@ If the expression is a composite, the last expression executed is the return val
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1297,7 +1253,6 @@ If the expression is a composite, the last expression executed is the return val
                               "description": "An optional expression to run before view transition",
                               "or": Array [
                                 Object {
-                                  "genericArguments": undefined,
                                   "ref": "Expression",
                                   "title": "NavigationBaseState.onEnd",
                                   "type": "ref",
@@ -1305,13 +1260,11 @@ If the expression is a composite, the last expression executed is the return val
                                 Object {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
-                                  "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": Object {
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1334,7 +1287,6 @@ If the expression is a composite, the last expression executed is the return val
                               "description": "An optional expression to run when this view renders",
                               "or": Array [
                                 Object {
-                                  "genericArguments": undefined,
                                   "ref": "Expression",
                                   "title": "NavigationBaseState.onStart",
                                   "type": "ref",
@@ -1342,13 +1294,11 @@ If the expression is a composite, the last expression executed is the return val
                                 Object {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
-                                  "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": Object {
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1415,7 +1365,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                               "description": "An optional expression to run before view transition",
                               "or": Array [
                                 Object {
-                                  "genericArguments": undefined,
                                   "ref": "Expression",
                                   "title": "NavigationBaseState.onEnd",
                                   "type": "ref",
@@ -1423,13 +1372,11 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                 Object {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
-                                  "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": Object {
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1452,7 +1399,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                               "description": "An optional expression to run when this view renders",
                               "or": Array [
                                 Object {
-                                  "genericArguments": undefined,
                                   "ref": "Expression",
                                   "title": "NavigationBaseState.onStart",
                                   "type": "ref",
@@ -1460,13 +1406,11 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                 Object {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
-                                  "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": Object {
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1504,7 +1448,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                           "transitions": Object {
                             "node": Object {
                               "description": "A mapping of transition-name to FlowState name",
-                              "genericTokens": undefined,
                               "keyType": Object {
                                 "type": "string",
                               },
@@ -1553,7 +1496,6 @@ The return value determines the transition to take",
                               "description": "An optional expression to run before view transition",
                               "or": Array [
                                 Object {
-                                  "genericArguments": undefined,
                                   "ref": "Expression",
                                   "title": "NavigationBaseState.onEnd",
                                   "type": "ref",
@@ -1561,13 +1503,11 @@ The return value determines the transition to take",
                                 Object {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
-                                  "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": Object {
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1590,7 +1530,6 @@ The return value determines the transition to take",
                               "description": "An optional expression to run when this view renders",
                               "or": Array [
                                 Object {
-                                  "genericArguments": undefined,
                                   "ref": "Expression",
                                   "title": "NavigationBaseState.onStart",
                                   "type": "ref",
@@ -1598,13 +1537,11 @@ The return value determines the transition to take",
                                 Object {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
-                                  "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": Object {
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1634,7 +1571,6 @@ The return value determines the transition to take",
                           "transitions": Object {
                             "node": Object {
                               "description": "A mapping of transition-name to FlowState name",
-                              "genericTokens": undefined,
                               "keyType": Object {
                                 "type": "string",
                               },
@@ -1681,7 +1617,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                               "description": "An optional expression to run before view transition",
                               "or": Array [
                                 Object {
-                                  "genericArguments": undefined,
                                   "ref": "Expression",
                                   "title": "NavigationBaseState.onEnd",
                                   "type": "ref",
@@ -1689,13 +1624,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                                 Object {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
-                                  "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": Object {
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1718,7 +1651,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                               "description": "An optional expression to run when this view renders",
                               "or": Array [
                                 Object {
-                                  "genericArguments": undefined,
                                   "ref": "Expression",
                                   "title": "NavigationBaseState.onStart",
                                   "type": "ref",
@@ -1726,13 +1658,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                                 Object {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
-                                  "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": Object {
                                     "exp": Object {
                                       "node": Object {
                                         "description": "The expression to run",
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "ExpressionObject.exp",
                                         "type": "ref",
@@ -1770,7 +1700,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                           "transitions": Object {
                             "node": Object {
                               "description": "A mapping of transition-name to FlowState name",
-                              "genericTokens": undefined,
                               "keyType": Object {
                                 "type": "string",
                               },
@@ -1820,7 +1749,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -1909,7 +1837,6 @@ The flow will wait for the embedded application to manage moving to the next sta
       "exp": Object {
         "node": Object {
           "description": "The expression to run",
-          "genericArguments": undefined,
           "ref": "Expression",
           "title": "ExpressionObject.exp",
           "type": "ref",
@@ -1931,20 +1858,17 @@ The flow will wait for the embedded application to manage moving to the next sta
           "type": "string",
         },
         Object {
-          "genericArguments": undefined,
           "ref": "Expression",
           "type": "ref",
         },
         Object {
           "additionalProperties": false,
           "description": "An object with an expression in it",
-          "genericTokens": undefined,
           "name": "ExpressionObject",
           "properties": Object {
             "exp": Object {
               "node": Object {
                 "description": "The expression to run",
-                "genericArguments": undefined,
                 "ref": "Expression",
                 "title": "ExpressionObject.exp",
                 "type": "ref",
@@ -1957,13 +1881,11 @@ The flow will wait for the embedded application to manage moving to the next sta
           "type": "object",
         },
         Object {
-          "genericTokens": undefined,
           "name": "NavigationFlowState",
           "or": Array [
             Object {
               "additionalProperties": false,
               "description": "A state representing a view",
-              "genericTokens": undefined,
               "name": "NavigationFlowViewState",
               "properties": Object {
                 "_comment": Object {
@@ -1988,7 +1910,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                 },
                 "exp": Object {
                   "node": Object {
-                    "name": undefined,
                     "title": "NavigationBaseState.exp",
                     "type": "never",
                   },
@@ -1999,7 +1920,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                     "description": "An optional expression to run before view transition",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onEnd",
                         "type": "ref",
@@ -2007,13 +1927,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2036,7 +1954,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                     "description": "An optional expression to run when this view renders",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onStart",
                         "type": "ref",
@@ -2044,13 +1961,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2088,7 +2003,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                 "transitions": Object {
                   "node": Object {
                     "description": "A mapping of transition-name to FlowState name",
-                    "genericTokens": undefined,
                     "keyType": Object {
                       "type": "string",
                     },
@@ -2110,7 +2024,6 @@ The flow will wait for the embedded application to manage moving to the next sta
             Object {
               "additionalProperties": false,
               "description": "An END state of the flow.",
-              "genericTokens": undefined,
               "name": "NavigationFlowEndState",
               "properties": Object {
                 "_comment": Object {
@@ -2123,7 +2036,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                 },
                 "exp": Object {
                   "node": Object {
-                    "name": undefined,
                     "title": "NavigationBaseState.exp",
                     "type": "never",
                   },
@@ -2134,7 +2046,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                     "description": "An optional expression to run before view transition",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onEnd",
                         "type": "ref",
@@ -2142,13 +2053,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2171,7 +2080,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                     "description": "An optional expression to run when this view renders",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onStart",
                         "type": "ref",
@@ -2179,13 +2087,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2228,7 +2134,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
             },
             Object {
               "additionalProperties": false,
-              "genericTokens": undefined,
               "name": "NavigationFlowFlowState",
               "properties": Object {
                 "_comment": Object {
@@ -2241,7 +2146,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                 },
                 "exp": Object {
                   "node": Object {
-                    "name": undefined,
                     "title": "NavigationBaseState.exp",
                     "type": "never",
                   },
@@ -2252,7 +2156,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                     "description": "An optional expression to run before view transition",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onEnd",
                         "type": "ref",
@@ -2260,13 +2163,11 @@ If this is a flow started from another flow, the outcome determines the flow tra
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2289,7 +2190,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                     "description": "An optional expression to run when this view renders",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onStart",
                         "type": "ref",
@@ -2297,13 +2197,11 @@ If this is a flow started from another flow, the outcome determines the flow tra
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2341,7 +2239,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                 "transitions": Object {
                   "node": Object {
                     "description": "A mapping of transition-name to FlowState name",
-                    "genericTokens": undefined,
                     "keyType": Object {
                       "type": "string",
                     },
@@ -2363,7 +2260,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
             Object {
               "additionalProperties": false,
               "description": "Action states execute an expression to determine the next state to transition to",
-              "genericTokens": undefined,
               "name": "NavigationFlowActionState",
               "properties": Object {
                 "_comment": Object {
@@ -2378,7 +2274,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                   "node": Object {
                     "description": "An expression to execute.
 The return value determines the transition to take",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "NavigationFlowActionState.exp",
                     "type": "ref",
@@ -2390,7 +2285,6 @@ The return value determines the transition to take",
                     "description": "An optional expression to run before view transition",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onEnd",
                         "type": "ref",
@@ -2398,13 +2292,11 @@ The return value determines the transition to take",
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2427,7 +2319,6 @@ The return value determines the transition to take",
                     "description": "An optional expression to run when this view renders",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onStart",
                         "type": "ref",
@@ -2435,13 +2326,11 @@ The return value determines the transition to take",
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2471,7 +2360,6 @@ The return value determines the transition to take",
                 "transitions": Object {
                   "node": Object {
                     "description": "A mapping of transition-name to FlowState name",
-                    "genericTokens": undefined,
                     "keyType": Object {
                       "type": "string",
                     },
@@ -2494,7 +2382,6 @@ The return value determines the transition to take",
               "additionalProperties": false,
               "description": "External Flow states represent states in the FSM that can't be resolved internally in Player.
 The flow will wait for the embedded application to manage moving to the next state via a transition",
-              "genericTokens": undefined,
               "name": "NavigationFlowExternalState",
               "properties": Object {
                 "_comment": Object {
@@ -2507,7 +2394,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                 },
                 "exp": Object {
                   "node": Object {
-                    "name": undefined,
                     "title": "NavigationBaseState.exp",
                     "type": "never",
                   },
@@ -2518,7 +2404,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                     "description": "An optional expression to run before view transition",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onEnd",
                         "type": "ref",
@@ -2526,13 +2411,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2555,7 +2438,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                     "description": "An optional expression to run when this view renders",
                     "or": Array [
                       Object {
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "NavigationBaseState.onStart",
                         "type": "ref",
@@ -2563,13 +2445,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                       Object {
                         "additionalProperties": false,
                         "description": "An object with an expression in it",
-                        "genericTokens": undefined,
                         "name": "ExpressionObject",
                         "properties": Object {
                           "exp": Object {
                             "node": Object {
                               "description": "The expression to run",
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "ExpressionObject.exp",
                               "type": "ref",
@@ -2607,7 +2487,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                 "transitions": Object {
                   "node": Object {
                     "description": "A mapping of transition-name to FlowState name",
-                    "genericTokens": undefined,
                     "keyType": Object {
                       "type": "string",
                     },
@@ -2643,7 +2522,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           "description": "An optional expression to run when this Flow ends",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationFlow.onEnd",
               "type": "ref",
@@ -2651,13 +2529,11 @@ The flow will wait for the embedded application to manage moving to the next sta
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -2680,7 +2556,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           "description": "An optional expression to run when this Flow starts",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationFlow.onStart",
               "type": "ref",
@@ -2688,13 +2563,11 @@ The flow will wait for the embedded application to manage moving to the next sta
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -2783,7 +2656,6 @@ So this explicity says there should never be an exp prop on a state node that's 
               "type": "never",
             },
             "true": Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "type": "ref",
             },
@@ -2796,7 +2668,6 @@ So this explicity says there should never be an exp prop on a state node that's 
           "description": "An optional expression to run before view transition",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onEnd",
               "type": "ref",
@@ -2804,13 +2675,11 @@ So this explicity says there should never be an exp prop on a state node that's 
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -2833,7 +2702,6 @@ So this explicity says there should never be an exp prop on a state node that's 
           "description": "An optional expression to run when this view renders",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onStart",
               "type": "ref",
@@ -2841,13 +2709,11 @@ So this explicity says there should never be an exp prop on a state node that's 
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -2924,7 +2790,6 @@ So this explicity says there should never be an exp prop on a state node that's 
               "type": "never",
             },
             "true": Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "type": "ref",
             },
@@ -2937,7 +2802,6 @@ So this explicity says there should never be an exp prop on a state node that's 
           "description": "An optional expression to run before view transition",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onEnd",
               "type": "ref",
@@ -2945,13 +2809,11 @@ So this explicity says there should never be an exp prop on a state node that's 
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -2974,7 +2836,6 @@ So this explicity says there should never be an exp prop on a state node that's 
           "description": "An optional expression to run when this view renders",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onStart",
               "type": "ref",
@@ -2982,13 +2843,11 @@ So this explicity says there should never be an exp prop on a state node that's 
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3018,7 +2877,6 @@ So this explicity says there should never be an exp prop on a state node that's 
       "transitions": Object {
         "node": Object {
           "description": "A mapping of transition-name to FlowState name",
-          "genericTokens": undefined,
           "keyType": Object {
             "type": "string",
           },
@@ -3076,7 +2934,6 @@ So this explicity says there should never be an exp prop on a state node that's 
           "description": "An optional expression to run before view transition",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onEnd",
               "type": "ref",
@@ -3084,13 +2941,11 @@ So this explicity says there should never be an exp prop on a state node that's 
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3113,7 +2968,6 @@ So this explicity says there should never be an exp prop on a state node that's 
           "description": "An optional expression to run when this view renders",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onStart",
               "type": "ref",
@@ -3121,13 +2975,11 @@ So this explicity says there should never be an exp prop on a state node that's 
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3165,7 +3017,6 @@ So this explicity says there should never be an exp prop on a state node that's 
       "transitions": Object {
         "node": Object {
           "description": "A mapping of transition-name to FlowState name",
-          "genericTokens": undefined,
           "keyType": Object {
             "type": "string",
           },
@@ -3211,7 +3062,6 @@ So this explicity says there should never be an exp prop on a state node that's 
           "description": "An optional expression to run before view transition",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onEnd",
               "type": "ref",
@@ -3219,13 +3069,11 @@ So this explicity says there should never be an exp prop on a state node that's 
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3248,7 +3096,6 @@ So this explicity says there should never be an exp prop on a state node that's 
           "description": "An optional expression to run when this view renders",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onStart",
               "type": "ref",
@@ -3256,13 +3103,11 @@ So this explicity says there should never be an exp prop on a state node that's 
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3321,7 +3166,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
         "node": Object {
           "description": "An expression to execute.
 The return value determines the transition to take",
-          "genericArguments": undefined,
           "ref": "Expression",
           "title": "NavigationFlowActionState.exp",
           "type": "ref",
@@ -3333,7 +3177,6 @@ The return value determines the transition to take",
           "description": "An optional expression to run before view transition",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onEnd",
               "type": "ref",
@@ -3341,13 +3184,11 @@ The return value determines the transition to take",
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3370,7 +3211,6 @@ The return value determines the transition to take",
           "description": "An optional expression to run when this view renders",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onStart",
               "type": "ref",
@@ -3378,13 +3218,11 @@ The return value determines the transition to take",
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3414,7 +3252,6 @@ The return value determines the transition to take",
       "transitions": Object {
         "node": Object {
           "description": "A mapping of transition-name to FlowState name",
-          "genericTokens": undefined,
           "keyType": Object {
             "type": "string",
           },
@@ -3461,7 +3298,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           "description": "An optional expression to run before view transition",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onEnd",
               "type": "ref",
@@ -3469,13 +3305,11 @@ The flow will wait for the embedded application to manage moving to the next sta
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3498,7 +3332,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           "description": "An optional expression to run when this view renders",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onStart",
               "type": "ref",
@@ -3506,13 +3339,11 @@ The flow will wait for the embedded application to manage moving to the next sta
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3550,7 +3381,6 @@ The flow will wait for the embedded application to manage moving to the next sta
       "transitions": Object {
         "node": Object {
           "description": "A mapping of transition-name to FlowState name",
-          "genericTokens": undefined,
           "keyType": Object {
             "type": "string",
           },
@@ -3595,7 +3425,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           "description": "An optional expression to run before view transition",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onEnd",
               "type": "ref",
@@ -3603,13 +3432,11 @@ The flow will wait for the embedded application to manage moving to the next sta
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3632,7 +3459,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           "description": "An optional expression to run when this view renders",
           "or": Array [
             Object {
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationBaseState.onStart",
               "type": "ref",
@@ -3640,13 +3466,11 @@ The flow will wait for the embedded application to manage moving to the next sta
             Object {
               "additionalProperties": false,
               "description": "An object with an expression in it",
-              "genericTokens": undefined,
               "name": "ExpressionObject",
               "properties": Object {
                 "exp": Object {
                   "node": Object {
                     "description": "The expression to run",
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "ExpressionObject.exp",
                     "type": "ref",
@@ -3684,7 +3508,6 @@ The flow will wait for the embedded application to manage moving to the next sta
       "transitions": Object {
         "node": Object {
           "description": "A mapping of transition-name to FlowState name",
-          "genericTokens": undefined,
           "keyType": Object {
             "type": "string",
           },
@@ -3710,7 +3533,6 @@ The flow will wait for the embedded application to manage moving to the next sta
       Object {
         "additionalProperties": false,
         "description": "A state representing a view",
-        "genericTokens": undefined,
         "name": "NavigationFlowViewState",
         "properties": Object {
           "_comment": Object {
@@ -3735,7 +3557,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           },
           "exp": Object {
             "node": Object {
-              "name": undefined,
               "title": "NavigationBaseState.exp",
               "type": "never",
             },
@@ -3746,7 +3567,6 @@ The flow will wait for the embedded application to manage moving to the next sta
               "description": "An optional expression to run before view transition",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onEnd",
                   "type": "ref",
@@ -3754,13 +3574,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -3783,7 +3601,6 @@ The flow will wait for the embedded application to manage moving to the next sta
               "description": "An optional expression to run when this view renders",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onStart",
                   "type": "ref",
@@ -3791,13 +3608,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -3835,7 +3650,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           "transitions": Object {
             "node": Object {
               "description": "A mapping of transition-name to FlowState name",
-              "genericTokens": undefined,
               "keyType": Object {
                 "type": "string",
               },
@@ -3857,7 +3671,6 @@ The flow will wait for the embedded application to manage moving to the next sta
       Object {
         "additionalProperties": false,
         "description": "An END state of the flow.",
-        "genericTokens": undefined,
         "name": "NavigationFlowEndState",
         "properties": Object {
           "_comment": Object {
@@ -3870,7 +3683,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           },
           "exp": Object {
             "node": Object {
-              "name": undefined,
               "title": "NavigationBaseState.exp",
               "type": "never",
             },
@@ -3881,7 +3693,6 @@ The flow will wait for the embedded application to manage moving to the next sta
               "description": "An optional expression to run before view transition",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onEnd",
                   "type": "ref",
@@ -3889,13 +3700,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -3918,7 +3727,6 @@ The flow will wait for the embedded application to manage moving to the next sta
               "description": "An optional expression to run when this view renders",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onStart",
                   "type": "ref",
@@ -3926,13 +3734,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -3975,7 +3781,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
       },
       Object {
         "additionalProperties": false,
-        "genericTokens": undefined,
         "name": "NavigationFlowFlowState",
         "properties": Object {
           "_comment": Object {
@@ -3988,7 +3793,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
           },
           "exp": Object {
             "node": Object {
-              "name": undefined,
               "title": "NavigationBaseState.exp",
               "type": "never",
             },
@@ -3999,7 +3803,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
               "description": "An optional expression to run before view transition",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onEnd",
                   "type": "ref",
@@ -4007,13 +3810,11 @@ If this is a flow started from another flow, the outcome determines the flow tra
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -4036,7 +3837,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
               "description": "An optional expression to run when this view renders",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onStart",
                   "type": "ref",
@@ -4044,13 +3844,11 @@ If this is a flow started from another flow, the outcome determines the flow tra
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -4088,7 +3886,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
           "transitions": Object {
             "node": Object {
               "description": "A mapping of transition-name to FlowState name",
-              "genericTokens": undefined,
               "keyType": Object {
                 "type": "string",
               },
@@ -4110,7 +3907,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
       Object {
         "additionalProperties": false,
         "description": "Action states execute an expression to determine the next state to transition to",
-        "genericTokens": undefined,
         "name": "NavigationFlowActionState",
         "properties": Object {
           "_comment": Object {
@@ -4125,7 +3921,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
             "node": Object {
               "description": "An expression to execute.
 The return value determines the transition to take",
-              "genericArguments": undefined,
               "ref": "Expression",
               "title": "NavigationFlowActionState.exp",
               "type": "ref",
@@ -4137,7 +3932,6 @@ The return value determines the transition to take",
               "description": "An optional expression to run before view transition",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onEnd",
                   "type": "ref",
@@ -4145,13 +3939,11 @@ The return value determines the transition to take",
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -4174,7 +3966,6 @@ The return value determines the transition to take",
               "description": "An optional expression to run when this view renders",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onStart",
                   "type": "ref",
@@ -4182,13 +3973,11 @@ The return value determines the transition to take",
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -4218,7 +4007,6 @@ The return value determines the transition to take",
           "transitions": Object {
             "node": Object {
               "description": "A mapping of transition-name to FlowState name",
-              "genericTokens": undefined,
               "keyType": Object {
                 "type": "string",
               },
@@ -4241,7 +4029,6 @@ The return value determines the transition to take",
         "additionalProperties": false,
         "description": "External Flow states represent states in the FSM that can't be resolved internally in Player.
 The flow will wait for the embedded application to manage moving to the next state via a transition",
-        "genericTokens": undefined,
         "name": "NavigationFlowExternalState",
         "properties": Object {
           "_comment": Object {
@@ -4254,7 +4041,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           },
           "exp": Object {
             "node": Object {
-              "name": undefined,
               "title": "NavigationBaseState.exp",
               "type": "never",
             },
@@ -4265,7 +4051,6 @@ The flow will wait for the embedded application to manage moving to the next sta
               "description": "An optional expression to run before view transition",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onEnd",
                   "type": "ref",
@@ -4273,13 +4058,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -4302,7 +4085,6 @@ The flow will wait for the embedded application to manage moving to the next sta
               "description": "An optional expression to run when this view renders",
               "or": Array [
                 Object {
-                  "genericArguments": undefined,
                   "ref": "Expression",
                   "title": "NavigationBaseState.onStart",
                   "type": "ref",
@@ -4310,13 +4092,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                 Object {
                   "additionalProperties": false,
                   "description": "An object with an expression in it",
-                  "genericTokens": undefined,
                   "name": "ExpressionObject",
                   "properties": Object {
                     "exp": Object {
                       "node": Object {
                         "description": "The expression to run",
-                        "genericArguments": undefined,
                         "ref": "Expression",
                         "title": "ExpressionObject.exp",
                         "type": "ref",
@@ -4354,7 +4134,6 @@ The flow will wait for the embedded application to manage moving to the next sta
           "transitions": Object {
             "node": Object {
               "description": "A mapping of transition-name to FlowState name",
-              "genericTokens": undefined,
               "keyType": Object {
                 "type": "string",
               },
@@ -4420,7 +4199,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                 "description": "An optional expression to run before view transition",
                 "or": Array [
                   Object {
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "NavigationBaseState.onEnd",
                     "type": "ref",
@@ -4428,13 +4206,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                   Object {
                     "additionalProperties": false,
                     "description": "An object with an expression in it",
-                    "genericTokens": undefined,
                     "name": "ExpressionObject",
                     "properties": Object {
                       "exp": Object {
                         "node": Object {
                           "description": "The expression to run",
-                          "genericArguments": undefined,
                           "ref": "Expression",
                           "title": "ExpressionObject.exp",
                           "type": "ref",
@@ -4457,7 +4233,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                 "description": "An optional expression to run when this view renders",
                 "or": Array [
                   Object {
-                    "genericArguments": undefined,
                     "ref": "Expression",
                     "title": "NavigationBaseState.onStart",
                     "type": "ref",
@@ -4465,13 +4240,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                   Object {
                     "additionalProperties": false,
                     "description": "An object with an expression in it",
-                    "genericTokens": undefined,
                     "name": "ExpressionObject",
                     "properties": Object {
                       "exp": Object {
                         "node": Object {
                           "description": "The expression to run",
-                          "genericArguments": undefined,
                           "ref": "Expression",
                           "title": "ExpressionObject.exp",
                           "type": "ref",
@@ -4634,7 +4407,6 @@ Any reference to _index_ is replaced with the current iteration index.",
       "data": Object {
         "node": Object {
           "description": "A pointer to the data-model containing an array of elements to map over",
-          "genericArguments": undefined,
           "ref": "Binding",
           "title": "Template.data",
           "type": "ref",
@@ -4680,7 +4452,6 @@ Any reference to _index_ is replaced with the current iteration index.",
         "type": "unknown",
       },
       "right": Object {
-        "genericArguments": undefined,
         "property": "validation",
         "ref": "Asset",
         "type": "ref",
@@ -4945,20 +4716,17 @@ This will be used to lookup the proper handler",
                           "type": "string",
                         },
                         Object {
-                          "genericArguments": undefined,
                           "ref": "Expression",
                           "type": "ref",
                         },
                         Object {
                           "additionalProperties": false,
                           "description": "An object with an expression in it",
-                          "genericTokens": undefined,
                           "name": "ExpressionObject",
                           "properties": Object {
                             "exp": Object {
                               "node": Object {
                                 "description": "The expression to run",
-                                "genericArguments": undefined,
                                 "ref": "Expression",
                                 "title": "ExpressionObject.exp",
                                 "type": "ref",
@@ -4971,13 +4739,11 @@ This will be used to lookup the proper handler",
                           "type": "object",
                         },
                         Object {
-                          "genericTokens": undefined,
                           "name": "NavigationFlowState",
                           "or": Array [
                             Object {
                               "additionalProperties": false,
                               "description": "A state representing a view",
-                              "genericTokens": undefined,
                               "name": "NavigationFlowViewState",
                               "properties": Object {
                                 "_comment": Object {
@@ -5002,7 +4768,6 @@ This will be used to lookup the proper handler",
                                 },
                                 "exp": Object {
                                   "node": Object {
-                                    "name": undefined,
                                     "title": "NavigationBaseState.exp",
                                     "type": "never",
                                   },
@@ -5013,7 +4778,6 @@ This will be used to lookup the proper handler",
                                     "description": "An optional expression to run before view transition",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onEnd",
                                         "type": "ref",
@@ -5021,13 +4785,11 @@ This will be used to lookup the proper handler",
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5050,7 +4812,6 @@ This will be used to lookup the proper handler",
                                     "description": "An optional expression to run when this view renders",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onStart",
                                         "type": "ref",
@@ -5058,13 +4819,11 @@ This will be used to lookup the proper handler",
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5102,7 +4861,6 @@ This will be used to lookup the proper handler",
                                 "transitions": Object {
                                   "node": Object {
                                     "description": "A mapping of transition-name to FlowState name",
-                                    "genericTokens": undefined,
                                     "keyType": Object {
                                       "type": "string",
                                     },
@@ -5124,7 +4882,6 @@ This will be used to lookup the proper handler",
                             Object {
                               "additionalProperties": false,
                               "description": "An END state of the flow.",
-                              "genericTokens": undefined,
                               "name": "NavigationFlowEndState",
                               "properties": Object {
                                 "_comment": Object {
@@ -5137,7 +4894,6 @@ This will be used to lookup the proper handler",
                                 },
                                 "exp": Object {
                                   "node": Object {
-                                    "name": undefined,
                                     "title": "NavigationBaseState.exp",
                                     "type": "never",
                                   },
@@ -5148,7 +4904,6 @@ This will be used to lookup the proper handler",
                                     "description": "An optional expression to run before view transition",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onEnd",
                                         "type": "ref",
@@ -5156,13 +4911,11 @@ This will be used to lookup the proper handler",
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5185,7 +4938,6 @@ This will be used to lookup the proper handler",
                                     "description": "An optional expression to run when this view renders",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onStart",
                                         "type": "ref",
@@ -5193,13 +4945,11 @@ This will be used to lookup the proper handler",
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5242,7 +4992,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                             },
                             Object {
                               "additionalProperties": false,
-                              "genericTokens": undefined,
                               "name": "NavigationFlowFlowState",
                               "properties": Object {
                                 "_comment": Object {
@@ -5255,7 +5004,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                 },
                                 "exp": Object {
                                   "node": Object {
-                                    "name": undefined,
                                     "title": "NavigationBaseState.exp",
                                     "type": "never",
                                   },
@@ -5266,7 +5014,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                     "description": "An optional expression to run before view transition",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onEnd",
                                         "type": "ref",
@@ -5274,13 +5021,11 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5303,7 +5048,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                     "description": "An optional expression to run when this view renders",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onStart",
                                         "type": "ref",
@@ -5311,13 +5055,11 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5355,7 +5097,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                 "transitions": Object {
                                   "node": Object {
                                     "description": "A mapping of transition-name to FlowState name",
-                                    "genericTokens": undefined,
                                     "keyType": Object {
                                       "type": "string",
                                     },
@@ -5377,7 +5118,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                             Object {
                               "additionalProperties": false,
                               "description": "Action states execute an expression to determine the next state to transition to",
-                              "genericTokens": undefined,
                               "name": "NavigationFlowActionState",
                               "properties": Object {
                                 "_comment": Object {
@@ -5392,7 +5132,6 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                   "node": Object {
                                     "description": "An expression to execute.
 The return value determines the transition to take",
-                                    "genericArguments": undefined,
                                     "ref": "Expression",
                                     "title": "NavigationFlowActionState.exp",
                                     "type": "ref",
@@ -5404,7 +5143,6 @@ The return value determines the transition to take",
                                     "description": "An optional expression to run before view transition",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onEnd",
                                         "type": "ref",
@@ -5412,13 +5150,11 @@ The return value determines the transition to take",
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5441,7 +5177,6 @@ The return value determines the transition to take",
                                     "description": "An optional expression to run when this view renders",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onStart",
                                         "type": "ref",
@@ -5449,13 +5184,11 @@ The return value determines the transition to take",
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5485,7 +5218,6 @@ The return value determines the transition to take",
                                 "transitions": Object {
                                   "node": Object {
                                     "description": "A mapping of transition-name to FlowState name",
-                                    "genericTokens": undefined,
                                     "keyType": Object {
                                       "type": "string",
                                     },
@@ -5508,7 +5240,6 @@ The return value determines the transition to take",
                               "additionalProperties": false,
                               "description": "External Flow states represent states in the FSM that can't be resolved internally in Player.
 The flow will wait for the embedded application to manage moving to the next state via a transition",
-                              "genericTokens": undefined,
                               "name": "NavigationFlowExternalState",
                               "properties": Object {
                                 "_comment": Object {
@@ -5521,7 +5252,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                                 },
                                 "exp": Object {
                                   "node": Object {
-                                    "name": undefined,
                                     "title": "NavigationBaseState.exp",
                                     "type": "never",
                                   },
@@ -5532,7 +5262,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                                     "description": "An optional expression to run before view transition",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onEnd",
                                         "type": "ref",
@@ -5540,13 +5269,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5569,7 +5296,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                                     "description": "An optional expression to run when this view renders",
                                     "or": Array [
                                       Object {
-                                        "genericArguments": undefined,
                                         "ref": "Expression",
                                         "title": "NavigationBaseState.onStart",
                                         "type": "ref",
@@ -5577,13 +5303,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                                       Object {
                                         "additionalProperties": false,
                                         "description": "An object with an expression in it",
-                                        "genericTokens": undefined,
                                         "name": "ExpressionObject",
                                         "properties": Object {
                                           "exp": Object {
                                             "node": Object {
                                               "description": "The expression to run",
-                                              "genericArguments": undefined,
                                               "ref": "Expression",
                                               "title": "ExpressionObject.exp",
                                               "type": "ref",
@@ -5621,7 +5345,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                                 "transitions": Object {
                                   "node": Object {
                                     "description": "A mapping of transition-name to FlowState name",
-                                    "genericTokens": undefined,
                                     "keyType": Object {
                                       "type": "string",
                                     },
@@ -5649,7 +5372,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                       "type": "or",
                     },
                     "description": "A state machine in the navigation",
-                    "genericTokens": undefined,
                     "name": "NavigationFlow",
                     "properties": Object {
                       "onEnd": Object {
@@ -5657,7 +5379,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                           "description": "An optional expression to run when this Flow ends",
                           "or": Array [
                             Object {
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "NavigationFlow.onEnd",
                               "type": "ref",
@@ -5665,13 +5386,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                             Object {
                               "additionalProperties": false,
                               "description": "An object with an expression in it",
-                              "genericTokens": undefined,
                               "name": "ExpressionObject",
                               "properties": Object {
                                 "exp": Object {
                                   "node": Object {
                                     "description": "The expression to run",
-                                    "genericArguments": undefined,
                                     "ref": "Expression",
                                     "title": "ExpressionObject.exp",
                                     "type": "ref",
@@ -5694,7 +5413,6 @@ The flow will wait for the embedded application to manage moving to the next sta
                           "description": "An optional expression to run when this Flow starts",
                           "or": Array [
                             Object {
-                              "genericArguments": undefined,
                               "ref": "Expression",
                               "title": "NavigationFlow.onStart",
                               "type": "ref",
@@ -5702,13 +5420,11 @@ The flow will wait for the embedded application to manage moving to the next sta
                             Object {
                               "additionalProperties": false,
                               "description": "An object with an expression in it",
-                              "genericTokens": undefined,
                               "name": "ExpressionObject",
                               "properties": Object {
                                 "exp": Object {
                                   "node": Object {
                                     "description": "The expression to run",
-                                    "genericArguments": undefined,
                                     "ref": "Expression",
                                     "title": "ExpressionObject.exp",
                                     "type": "ref",
@@ -5791,7 +5507,6 @@ Any reads for this property will result in this default value being written to t
                     },
                     "description": "A reference to a specific data format to use.
 If none is specified, will fallback to that of the base type",
-                    "genericTokens": undefined,
                     "name": "Reference",
                     "properties": Object {
                       "type": Object {
@@ -5803,7 +5518,6 @@ If none is specified, will fallback to that of the base type",
                         "required": true,
                       },
                     },
-                    "source": undefined,
                     "title": "DataType.format",
                     "type": "object",
                   },
@@ -5834,7 +5548,6 @@ These will add to any base validations associated with the \\"type\\"",
                         "type": "unknown",
                       },
                       "description": "A reference to a validation object",
-                      "genericTokens": undefined,
                       "name": "Reference",
                       "properties": Object {
                         "dataTarget": Object {
@@ -5862,7 +5575,6 @@ In the off chance you'd like this validator to run against the formatted value (
                         "displayTarget": Object {
                           "node": Object {
                             "description": "Where the error should be displayed",
-                            "genericTokens": undefined,
                             "name": "DisplayTarget",
                             "or": Array [
                               Object {
@@ -5881,7 +5593,6 @@ In the off chance you'd like this validator to run against the formatted value (
                                 "type": "string",
                               },
                             ],
-                            "source": undefined,
                             "title": "Reference.displayTarget",
                             "type": "or",
                           },
@@ -5898,7 +5609,6 @@ In the off chance you'd like this validator to run against the formatted value (
                         "severity": Object {
                           "node": Object {
                             "description": "An optional means of overriding the default severity of the validation if triggered",
-                            "genericTokens": undefined,
                             "name": "Severity",
                             "or": Array [
                               Object {
@@ -5912,7 +5622,6 @@ In the off chance you'd like this validator to run against the formatted value (
                                 "type": "string",
                               },
                             ],
-                            "source": undefined,
                             "title": "Reference.severity",
                             "type": "or",
                           },
@@ -5921,7 +5630,6 @@ In the off chance you'd like this validator to run against the formatted value (
                         "trigger": Object {
                           "node": Object {
                             "description": "When to run this particular validation",
-                            "genericTokens": undefined,
                             "name": "Trigger",
                             "or": Array [
                               Object {
@@ -5940,7 +5648,6 @@ In the off chance you'd like this validator to run against the formatted value (
                                 "type": "string",
                               },
                             ],
-                            "source": undefined,
                             "title": "Reference.trigger",
                             "type": "or",
                           },
@@ -5956,7 +5663,6 @@ This will be used to lookup the proper handler",
                           "required": true,
                         },
                       },
-                      "source": undefined,
                       "title": "Reference",
                       "type": "object",
                     },
@@ -5966,7 +5672,6 @@ This will be used to lookup the proper handler",
                   "required": false,
                 },
               },
-              "source": undefined,
               "title": "DataType",
               "type": "object",
             },
@@ -6091,7 +5796,6 @@ In the off chance you'd like this validator to run against the formatted value (
                             "displayTarget": Object {
                               "node": Object {
                                 "description": "Where the error should be displayed",
-                                "genericTokens": undefined,
                                 "name": "DisplayTarget",
                                 "or": Array [
                                   Object {
@@ -6110,7 +5814,6 @@ In the off chance you'd like this validator to run against the formatted value (
                                     "type": "string",
                                   },
                                 ],
-                                "source": undefined,
                                 "title": "Reference.displayTarget",
                                 "type": "or",
                               },
@@ -6127,7 +5830,6 @@ In the off chance you'd like this validator to run against the formatted value (
                             "severity": Object {
                               "node": Object {
                                 "description": "An optional means of overriding the default severity of the validation if triggered",
-                                "genericTokens": undefined,
                                 "name": "Severity",
                                 "or": Array [
                                   Object {
@@ -6141,7 +5843,6 @@ In the off chance you'd like this validator to run against the formatted value (
                                     "type": "string",
                                   },
                                 ],
-                                "source": undefined,
                                 "title": "Reference.severity",
                                 "type": "or",
                               },
@@ -6150,7 +5851,6 @@ In the off chance you'd like this validator to run against the formatted value (
                             "trigger": Object {
                               "node": Object {
                                 "description": "When to run this particular validation",
-                                "genericTokens": undefined,
                                 "name": "Trigger",
                                 "or": Array [
                                   Object {
@@ -6169,7 +5869,6 @@ In the off chance you'd like this validator to run against the formatted value (
                                     "type": "string",
                                   },
                                 ],
-                                "source": undefined,
                                 "title": "Reference.trigger",
                                 "type": "or",
                               },
@@ -6225,7 +5924,6 @@ This will be used to lookup the proper handler",
                 "type": "unknown",
               },
               "right": Object {
-                "genericArguments": undefined,
                 "property": "validation",
                 "ref": "Asset",
                 "type": "ref",
@@ -6234,12 +5932,10 @@ This will be used to lookup the proper handler",
             "genericTokens": Array [
               Object {
                 "constraints": Object {
-                  "genericArguments": undefined,
                   "ref": "Asset",
                   "type": "ref",
                 },
                 "default": Object {
-                  "genericArguments": undefined,
                   "ref": "Asset",
                   "type": "ref",
                 },
@@ -6271,7 +5967,6 @@ This will be used to lookup the proper handler",
                             "additionalProperties": Object {
                               "type": "unknown",
                             },
-                            "genericTokens": undefined,
                             "name": "CrossfieldReference",
                             "properties": Object {
                               "dataTarget": Object {
@@ -6285,7 +5980,6 @@ This will be used to lookup the proper handler",
                               "displayTarget": Object {
                                 "node": Object {
                                   "description": "Where the error should be displayed",
-                                  "genericTokens": undefined,
                                   "name": "DisplayTarget",
                                   "or": Array [
                                     Object {
@@ -6304,7 +5998,6 @@ This will be used to lookup the proper handler",
                                       "type": "string",
                                     },
                                   ],
-                                  "source": undefined,
                                   "title": "Reference.displayTarget",
                                   "type": "or",
                                 },
@@ -6321,7 +6014,6 @@ This will be used to lookup the proper handler",
                               "ref": Object {
                                 "node": Object {
                                   "description": "The binding to associate this validation with",
-                                  "genericArguments": undefined,
                                   "ref": "Binding",
                                   "title": "CrossfieldReference.ref",
                                   "type": "ref",
@@ -6331,7 +6023,6 @@ This will be used to lookup the proper handler",
                               "severity": Object {
                                 "node": Object {
                                   "description": "An optional means of overriding the default severity of the validation if triggered",
-                                  "genericTokens": undefined,
                                   "name": "Severity",
                                   "or": Array [
                                     Object {
@@ -6345,7 +6036,6 @@ This will be used to lookup the proper handler",
                                       "type": "string",
                                     },
                                   ],
-                                  "source": undefined,
                                   "title": "Reference.severity",
                                   "type": "or",
                                 },
@@ -6354,7 +6044,6 @@ This will be used to lookup the proper handler",
                               "trigger": Object {
                                 "node": Object {
                                   "description": "When to run this particular validation",
-                                  "genericTokens": undefined,
                                   "name": "Trigger",
                                   "or": Array [
                                     Object {
@@ -6373,7 +6062,6 @@ This will be used to lookup the proper handler",
                                       "type": "string",
                                     },
                                   ],
-                                  "source": undefined,
                                   "title": "Reference.trigger",
                                   "type": "or",
                                 },
@@ -6389,7 +6077,6 @@ This will be used to lookup the proper handler",
                                 "required": true,
                               },
                             },
-                            "source": undefined,
                             "title": "CrossfieldReference",
                             "type": "object",
                           },

--- a/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
@@ -4675,6 +4675,17 @@ Any reference to _index_ is replaced with the current iteration index.",
     "type": "object",
   },
   Object {
+    "check": Object {
+      "left": Object {
+        "type": "unknown",
+      },
+      "right": Object {
+        "genericArguments": undefined,
+        "property": "validation",
+        "ref": "Asset",
+        "type": "ref",
+      },
+    },
     "genericTokens": Array [
       Object {
         "constraints": Object {
@@ -4691,10 +4702,164 @@ Any reference to _index_ is replaced with the current iteration index.",
       },
     ],
     "name": "View",
-    "ref": "T",
     "source": "filename.ts",
     "title": "View",
-    "type": "ref",
+    "type": "conditional",
+    "value": Object {
+      "false": Object {
+        "ref": "T",
+        "type": "ref",
+      },
+      "true": Object {
+        "and": Array [
+          Object {
+            "ref": "T",
+            "type": "ref",
+          },
+          Object {
+            "additionalProperties": false,
+            "properties": Object {
+              "validation": Object {
+                "node": Object {
+                  "description": "Each view can optionally supply a list of validations to run against a particular view",
+                  "elementType": Object {
+                    "additionalProperties": Object {
+                      "type": "unknown",
+                    },
+                    "genericTokens": undefined,
+                    "name": "CrossfieldReference",
+                    "properties": Object {
+                      "dataTarget": Object {
+                        "node": Object {
+                          "description": "Cross-field references and validation must run against the default (deformatted) value",
+                          "title": "CrossfieldReference.dataTarget",
+                          "type": "never",
+                        },
+                        "required": false,
+                      },
+                      "displayTarget": Object {
+                        "node": Object {
+                          "description": "Where the error should be displayed",
+                          "genericTokens": undefined,
+                          "name": "DisplayTarget",
+                          "or": Array [
+                            Object {
+                              "const": "page",
+                              "title": "DisplayTarget",
+                              "type": "string",
+                            },
+                            Object {
+                              "const": "section",
+                              "title": "DisplayTarget",
+                              "type": "string",
+                            },
+                            Object {
+                              "const": "field",
+                              "title": "DisplayTarget",
+                              "type": "string",
+                            },
+                          ],
+                          "source": undefined,
+                          "title": "Reference.displayTarget",
+                          "type": "or",
+                        },
+                        "required": false,
+                      },
+                      "message": Object {
+                        "node": Object {
+                          "description": "An optional means of overriding the default message if the validation is triggered",
+                          "title": "Reference.message",
+                          "type": "string",
+                        },
+                        "required": false,
+                      },
+                      "ref": Object {
+                        "node": Object {
+                          "description": "The binding to associate this validation with",
+                          "genericArguments": undefined,
+                          "ref": "Binding",
+                          "title": "CrossfieldReference.ref",
+                          "type": "ref",
+                        },
+                        "required": false,
+                      },
+                      "severity": Object {
+                        "node": Object {
+                          "description": "An optional means of overriding the default severity of the validation if triggered",
+                          "genericTokens": undefined,
+                          "name": "Severity",
+                          "or": Array [
+                            Object {
+                              "const": "error",
+                              "title": "Severity",
+                              "type": "string",
+                            },
+                            Object {
+                              "const": "warning",
+                              "title": "Severity",
+                              "type": "string",
+                            },
+                          ],
+                          "source": undefined,
+                          "title": "Reference.severity",
+                          "type": "or",
+                        },
+                        "required": false,
+                      },
+                      "trigger": Object {
+                        "node": Object {
+                          "description": "When to run this particular validation",
+                          "genericTokens": undefined,
+                          "name": "Trigger",
+                          "or": Array [
+                            Object {
+                              "const": "navigation",
+                              "title": "Trigger",
+                              "type": "string",
+                            },
+                            Object {
+                              "const": "change",
+                              "title": "Trigger",
+                              "type": "string",
+                            },
+                            Object {
+                              "const": "load",
+                              "title": "Trigger",
+                              "type": "string",
+                            },
+                          ],
+                          "source": undefined,
+                          "title": "Reference.trigger",
+                          "type": "or",
+                        },
+                        "required": false,
+                      },
+                      "type": Object {
+                        "node": Object {
+                          "description": "The name of the referenced validation type
+This will be used to lookup the proper handler",
+                          "title": "Reference.type",
+                          "type": "string",
+                        },
+                        "required": true,
+                      },
+                    },
+                    "source": undefined,
+                    "title": "CrossfieldReference",
+                    "type": "object",
+                  },
+                  "title": "validation",
+                  "type": "array",
+                },
+                "required": false,
+              },
+            },
+            "type": "object",
+          },
+        ],
+        "type": "and",
+      },
+    },
   },
   Object {
     "additionalProperties": Object {
@@ -6055,10 +6220,191 @@ This will be used to lookup the proper handler",
         "node": Object {
           "description": "A list of views (each with an ID) that can be shown to a user",
           "elementType": Object {
+            "check": Object {
+              "left": Object {
+                "type": "unknown",
+              },
+              "right": Object {
+                "genericArguments": undefined,
+                "property": "validation",
+                "ref": "Asset",
+                "type": "ref",
+              },
+            },
+            "genericTokens": Array [
+              Object {
+                "constraints": Object {
+                  "genericArguments": undefined,
+                  "ref": "Asset",
+                  "type": "ref",
+                },
+                "default": Object {
+                  "genericArguments": undefined,
+                  "ref": "Asset",
+                  "type": "ref",
+                },
+                "symbol": "T",
+              },
+            ],
             "name": "View",
-            "ref": "T",
+            "source": "filename.ts",
             "title": "View",
-            "type": "ref",
+            "type": "conditional",
+            "value": Object {
+              "false": Object {
+                "ref": "T",
+                "type": "ref",
+              },
+              "true": Object {
+                "and": Array [
+                  Object {
+                    "ref": "T",
+                    "type": "ref",
+                  },
+                  Object {
+                    "additionalProperties": false,
+                    "properties": Object {
+                      "validation": Object {
+                        "node": Object {
+                          "description": "Each view can optionally supply a list of validations to run against a particular view",
+                          "elementType": Object {
+                            "additionalProperties": Object {
+                              "type": "unknown",
+                            },
+                            "genericTokens": undefined,
+                            "name": "CrossfieldReference",
+                            "properties": Object {
+                              "dataTarget": Object {
+                                "node": Object {
+                                  "description": "Cross-field references and validation must run against the default (deformatted) value",
+                                  "title": "CrossfieldReference.dataTarget",
+                                  "type": "never",
+                                },
+                                "required": false,
+                              },
+                              "displayTarget": Object {
+                                "node": Object {
+                                  "description": "Where the error should be displayed",
+                                  "genericTokens": undefined,
+                                  "name": "DisplayTarget",
+                                  "or": Array [
+                                    Object {
+                                      "const": "page",
+                                      "title": "DisplayTarget",
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "const": "section",
+                                      "title": "DisplayTarget",
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "const": "field",
+                                      "title": "DisplayTarget",
+                                      "type": "string",
+                                    },
+                                  ],
+                                  "source": undefined,
+                                  "title": "Reference.displayTarget",
+                                  "type": "or",
+                                },
+                                "required": false,
+                              },
+                              "message": Object {
+                                "node": Object {
+                                  "description": "An optional means of overriding the default message if the validation is triggered",
+                                  "title": "Reference.message",
+                                  "type": "string",
+                                },
+                                "required": false,
+                              },
+                              "ref": Object {
+                                "node": Object {
+                                  "description": "The binding to associate this validation with",
+                                  "genericArguments": undefined,
+                                  "ref": "Binding",
+                                  "title": "CrossfieldReference.ref",
+                                  "type": "ref",
+                                },
+                                "required": false,
+                              },
+                              "severity": Object {
+                                "node": Object {
+                                  "description": "An optional means of overriding the default severity of the validation if triggered",
+                                  "genericTokens": undefined,
+                                  "name": "Severity",
+                                  "or": Array [
+                                    Object {
+                                      "const": "error",
+                                      "title": "Severity",
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "const": "warning",
+                                      "title": "Severity",
+                                      "type": "string",
+                                    },
+                                  ],
+                                  "source": undefined,
+                                  "title": "Reference.severity",
+                                  "type": "or",
+                                },
+                                "required": false,
+                              },
+                              "trigger": Object {
+                                "node": Object {
+                                  "description": "When to run this particular validation",
+                                  "genericTokens": undefined,
+                                  "name": "Trigger",
+                                  "or": Array [
+                                    Object {
+                                      "const": "navigation",
+                                      "title": "Trigger",
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "const": "change",
+                                      "title": "Trigger",
+                                      "type": "string",
+                                    },
+                                    Object {
+                                      "const": "load",
+                                      "title": "Trigger",
+                                      "type": "string",
+                                    },
+                                  ],
+                                  "source": undefined,
+                                  "title": "Reference.trigger",
+                                  "type": "or",
+                                },
+                                "required": false,
+                              },
+                              "type": Object {
+                                "node": Object {
+                                  "description": "The name of the referenced validation type
+This will be used to lookup the proper handler",
+                                  "title": "Reference.type",
+                                  "type": "string",
+                                },
+                                "required": true,
+                              },
+                            },
+                            "source": undefined,
+                            "title": "CrossfieldReference",
+                            "type": "object",
+                          },
+                          "title": "validation",
+                          "type": "array",
+                        },
+                        "required": false,
+                      },
+                    },
+                    "type": "object",
+                  },
+                ],
+                "type": "and",
+              },
+            },
           },
           "title": "Flow.views",
           "type": "array",

--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -243,6 +243,98 @@ Array [
 ]
 `;
 
+exports[`Edge Cases Modifying Cache References 1`] = `
+Array [
+  Object {
+    "and": Array [
+      Object {
+        "and": Array [
+          Object {
+            "genericTokens": undefined,
+            "name": "types",
+            "or": Array [
+              Object {
+                "additionalProperties": false,
+                "genericTokens": undefined,
+                "name": "foo",
+                "properties": Object {
+                  "foo": Object {
+                    "node": Object {
+                      "title": "foo.foo",
+                      "type": "string",
+                    },
+                    "required": true,
+                  },
+                },
+                "source": "filename.ts",
+                "title": "foo",
+                "type": "object",
+              },
+              Object {
+                "additionalProperties": false,
+                "genericTokens": undefined,
+                "name": "bar",
+                "properties": Object {
+                  "bar": Object {
+                    "node": Object {
+                      "title": "bar.bar",
+                      "type": "number",
+                    },
+                    "required": true,
+                  },
+                },
+                "source": "filename.ts",
+                "title": "bar",
+                "type": "object",
+              },
+            ],
+            "source": "filename.ts",
+            "title": "types",
+            "type": "or",
+          },
+          Object {
+            "additionalProperties": false,
+            "properties": Object {
+              "baz": Object {
+                "node": Object {
+                  "title": "baz",
+                  "type": "number",
+                },
+                "required": true,
+              },
+            },
+            "type": "object",
+          },
+        ],
+        "genericTokens": undefined,
+        "name": "requiredTypes",
+        "source": "filename.ts",
+        "title": "requiredTypes",
+        "type": "and",
+      },
+      Object {
+        "additionalProperties": false,
+        "properties": Object {
+          "baz": Object {
+            "node": Object {
+              "title": "baz",
+              "type": "number",
+            },
+            "required": false,
+          },
+        },
+        "type": "object",
+      },
+    ],
+    "genericTokens": undefined,
+    "name": "test",
+    "source": "filename.ts",
+    "title": "test",
+    "type": "and",
+  },
+]
+`;
+
 exports[`Generic Declarations Basic Generic Type 1`] = `
 Array [
   Object {

--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -707,3 +707,29 @@ Array [
   },
 ]
 `;
+
+exports[`Type with typeof Indexing 1`] = `
+Array [
+  Object {
+    "genericTokens": undefined,
+    "name": "options",
+    "or": Array [
+      Object {
+        "const": "one",
+        "type": "string",
+      },
+      Object {
+        "const": "two",
+        "type": "string",
+      },
+      Object {
+        "const": "three",
+        "type": "string",
+      },
+    ],
+    "source": "filename.ts",
+    "title": "options",
+    "type": "or",
+  },
+]
+`;

--- a/xlr/converters/src/__tests__/common-to-ts.test.ts
+++ b/xlr/converters/src/__tests__/common-to-ts.test.ts
@@ -159,4 +159,36 @@ describe('Type Exports', () => {
       }
     `);
   });
+
+  it('Template Type Conversion', () => {
+    const xlr = {
+      name: 'BindingRef',
+      title: 'BindingRef',
+      type: 'template',
+      format: '{{.*}}',
+    } as NamedType;
+
+    const converter = new TSWriter(ts.factory);
+
+    const { type: tsNode, referencedTypes: referencedImports } =
+      converter.convertNamedType(xlr);
+
+    const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+    const resultFile = ts.createSourceFile(
+      'output.d.ts',
+      '',
+      ts.ScriptTarget.ES2017,
+      false, // setParentNodes
+      ts.ScriptKind.TS
+    );
+
+    const nodeText = printer.printNode(
+      ts.EmitHint.Unspecified,
+      tsNode,
+      resultFile
+    );
+
+    expect(nodeText).toMatchSnapshot();
+    expect(referencedImports).toBeUndefined();
+  });
 });

--- a/xlr/converters/src/__tests__/common-to-ts.test.ts
+++ b/xlr/converters/src/__tests__/common-to-ts.test.ts
@@ -6,26 +6,9 @@ describe('Type Exports', () => {
   it('Basic Type Conversion', () => {
     const xlr = {
       name: 'ActionAsset',
-      source: 'ActionAsset.ts',
       type: 'object',
+      source: 'common-to-ts.test.ts',
       properties: {
-        id: {
-          required: true,
-          node: {
-            type: 'string',
-            title: 'Asset.id',
-            description: 'Each asset requires a unique id per view',
-          },
-        },
-        type: {
-          required: true,
-          node: {
-            type: 'string',
-            const: 'action',
-            title:
-              'The asset type determines the semantics of how a user interacts with a page',
-          },
-        },
         value: {
           required: false,
           node: {
@@ -40,6 +23,12 @@ describe('Type Exports', () => {
           node: {
             type: 'ref',
             ref: 'AssetWrapper<AnyTextAsset>',
+            genericArguments: [
+              {
+                type: 'ref',
+                ref: 'AnyTextAsset',
+              },
+            ],
             title: 'ActionAsset.label',
             description: "A text-like asset for the action's label",
           },
@@ -72,6 +61,8 @@ describe('Type Exports', () => {
                 required: false,
                 node: {
                   name: 'BeaconDataType',
+                  source:
+                    '/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/node_modules/@player-ui/beacon-plugin/dist/index.d.ts',
                   type: 'or',
                   or: [
                     {
@@ -127,6 +118,16 @@ describe('Type Exports', () => {
           },
         },
       ],
+      extends: {
+        type: 'ref',
+        ref: "Asset<'action'>",
+        genericArguments: [
+          {
+            type: 'string',
+            const: 'action',
+          },
+        ],
+      },
     } as NamedType;
 
     const converter = new TSWriter(ts.factory);

--- a/xlr/converters/src/__tests__/player.test.ts
+++ b/xlr/converters/src/__tests__/player.test.ts
@@ -1,7 +1,7 @@
 import { setupTestEnv } from '@player-tools/xlr-utils';
 import { TsConverter } from '..';
 
-it('Player Types Export', async () => {
+it('Player Types Export', () => {
   const customPrimitives = [
     'Expression',
     'Asset',
@@ -444,7 +444,7 @@ export interface Flow<T extends Asset = Asset> {
 
 `;
 
-  const { sf, tc } = await setupTestEnv(sc);
+  const { sf, tc } = setupTestEnv(sc);
   const converter = new TsConverter(tc, customPrimitives);
   const XLR = converter.convertSourceFile(sf).data.types;
 

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -437,3 +437,32 @@ describe('Type with typeof', () => {
     expect(XLR).toMatchSnapshot();
   });
 });
+
+describe('Edge Cases', () => {
+  it('Modifying Cache References', async () => {
+    const sc = `
+    interface foo {
+      foo: string;
+    }
+    
+    interface bar {
+      bar: number;
+    }
+    
+    type types = foo | bar;
+    
+    type requiredTypes = types & {
+      baz: number;
+    };
+    
+    export type test = requiredTypes & Partial<Pick<requiredTypes, 'baz'>>;    
+
+    `;
+
+    const { sf, tc } = await setupTestEnv(sc);
+    const converter = new TsConverter(tc);
+    const XLR = converter.convertSourceFile(sf).data.types;
+
+    expect(XLR).toMatchSnapshot();
+  });
+});

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -3,24 +3,24 @@ import { setupTestEnv } from '@player-tools/xlr-utils';
 import { TsConverter } from '..';
 
 describe('Type Exports', () => {
-  it('Basic Array Type', async () => {
+  it('Basic Array Type', () => {
     const sc = `
     export type Foo = Array<string>
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Basic Union Type', async () => {
+  it('Basic Union Type', () => {
     const sc = `
     export type Foo = number | string
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
@@ -29,7 +29,7 @@ describe('Type Exports', () => {
 });
 
 describe('Interface Exports', () => {
-  it('Basic Interface Type', async () => {
+  it('Basic Interface Type', () => {
     const sc = `
     export interface Foo {
       bar: string
@@ -37,14 +37,14 @@ describe('Interface Exports', () => {
     }
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Interface with Optional parameters', async () => {
+  it('Interface with Optional parameters', () => {
     const sc = `
     export interface Foo {
       bar: string
@@ -52,14 +52,14 @@ describe('Interface Exports', () => {
     }
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Interface with Inheritance', async () => {
+  it('Interface with Inheritance', () => {
     const sc = `
 
     interface Base {
@@ -72,14 +72,14 @@ describe('Interface Exports', () => {
     }
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Implementing more than one Interfaces', async () => {
+  it('Implementing more than one Interfaces', () => {
     const sc = `
 
     interface Foo{
@@ -96,7 +96,7 @@ describe('Interface Exports', () => {
 
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
@@ -105,45 +105,45 @@ describe('Interface Exports', () => {
 });
 
 describe('Generic Declarations', () => {
-  it('Basic Generic Type', async () => {
+  it('Basic Generic Type', () => {
     const sc = `
     export type Foo<T> = string | T
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Generic with Constraints', async () => {
+  it('Generic with Constraints', () => {
     const sc = `
     export type Foo<T extends string = string > = number | T
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Implementing Generic Type', async () => {
+  it('Implementing Generic Type', () => {
     const sc = `
     type Foo<T> = string | T
 
     export type Bar = boolean | Foo<number>
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Interface with Generics', async () => {
+  it('Interface with Generics', () => {
     const sc = `
 
     export interface Foo<T>{
@@ -151,14 +151,14 @@ describe('Generic Declarations', () => {
     }
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Interface with Generics and Constraints', async () => {
+  it('Interface with Generics and Constraints', () => {
     const sc = `
 
     export interface Foo<T extends string = string>{
@@ -166,14 +166,14 @@ describe('Generic Declarations', () => {
     }
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Implementing Interface with Generics', async () => {
+  it('Implementing Interface with Generics', () => {
     const sc = `
 
     interface Base<T extends string = string>{
@@ -186,14 +186,14 @@ describe('Generic Declarations', () => {
 
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Implementing an generic wrapped interface', async () => {
+  it('Implementing an generic wrapped interface', () => {
     const sc = `
 
     interface base {
@@ -207,7 +207,7 @@ describe('Generic Declarations', () => {
 
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
@@ -216,7 +216,7 @@ describe('Generic Declarations', () => {
 });
 
 describe('Complex Types', () => {
-  it('Pick', async () => {
+  it('Pick', () => {
     const sc = `
     interface foo {
       bar: string
@@ -225,14 +225,14 @@ describe('Complex Types', () => {
     export type Bar = Pick<foo,"bar">
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Pick with interface union', async () => {
+  it('Pick with interface union', () => {
     const sc = `
     interface foo {
       far: string
@@ -249,14 +249,14 @@ describe('Complex Types', () => {
     export type Bar = Pick<test,"far">
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Pick with interface intersection', async () => {
+  it('Pick with interface intersection', () => {
     const sc = `
     interface foo {
       far: string
@@ -273,14 +273,14 @@ describe('Complex Types', () => {
     export type Bar = Pick<test,"far">
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Omit', async () => {
+  it('Omit', () => {
     const sc = `
     interface foo {
       bar: string
@@ -289,14 +289,14 @@ describe('Complex Types', () => {
     export type Bar = Omit<foo,"bar">
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Omit with type union', async () => {
+  it('Omit with type union', () => {
     const sc = `
     interface foo {
       far: string
@@ -313,14 +313,14 @@ describe('Complex Types', () => {
     export type Bar = Omit<test,"bax">
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Omit with type intersection', async () => {
+  it('Omit with type intersection', () => {
     const sc = `
     interface foo {
       far: string
@@ -337,7 +337,7 @@ describe('Complex Types', () => {
     export type Bar = Omit<test,"far">
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
@@ -346,22 +346,22 @@ describe('Complex Types', () => {
 });
 
 describe('String Templates', () => {
-  it('Basic', async () => {
+  it('Basic', () => {
     const sc =
       'export type Bar = `String is a ${string}, number is a ${number} and boolean is a ${boolean}`';
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Type References', async () => {
+  it('Type References', () => {
     const sc =
       'type Foo = string; export type Bar = `String is a ${Foo}, number is a ${number} and boolean is a ${boolean}`';
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
@@ -370,7 +370,7 @@ describe('String Templates', () => {
 });
 
 describe('Index Types', () => {
-  it('Basic', async () => {
+  it('Basic', () => {
     const sc = `
     interface base {
       foo: string;
@@ -383,14 +383,14 @@ describe('Index Types', () => {
 
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Complex Types', async () => {
+  it('Complex Types', () => {
     const sc = `
 
     interface something {
@@ -409,7 +409,7 @@ describe('Index Types', () => {
 
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
@@ -418,7 +418,7 @@ describe('Index Types', () => {
 });
 
 describe('Type with typeof', () => {
-  it('Indexing', async () => {
+  it('Indexing', () => {
     const sc = `
     const options = [ 
       "one",
@@ -430,7 +430,7 @@ describe('Type with typeof', () => {
 
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 
@@ -439,7 +439,7 @@ describe('Type with typeof', () => {
 });
 
 describe('Edge Cases', () => {
-  it('Modifying Cache References', async () => {
+  it('Modifying Cache References', () => {
     const sc = `
     interface foo {
       foo: string;
@@ -459,7 +459,7 @@ describe('Edge Cases', () => {
 
     `;
 
-    const { sf, tc } = await setupTestEnv(sc);
+    const { sf, tc } = setupTestEnv(sc);
     const converter = new TsConverter(tc);
     const XLR = converter.convertSourceFile(sf).data.types;
 

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -416,3 +416,24 @@ describe('Index Types', () => {
     expect(XLR).toMatchSnapshot();
   });
 });
+
+describe('Type with typeof', () => {
+  it('Indexing', async () => {
+    const sc = `
+    const options = [ 
+      "one",
+      "two",
+      "three"
+    ] as const
+    
+    export type options = typeof options[number];
+
+    `;
+
+    const { sf, tc } = await setupTestEnv(sc);
+    const converter = new TsConverter(tc);
+    const XLR = converter.convertSourceFile(sf).data.types;
+
+    expect(XLR).toMatchSnapshot();
+  });
+});

--- a/xlr/converters/src/ts-to-xlr.ts
+++ b/xlr/converters/src/ts-to-xlr.ts
@@ -166,7 +166,11 @@ export class TsConverter {
   /** Converts an arbitrary ts.TypeNode to XLRs */
   public convertTsTypeNode(node: ts.TypeNode): NodeType | undefined {
     if (this.context.cache.convertedNodes.has(node)) {
-      return this.context.cache.convertedNodes.get(node);
+      const cachedType = this.context.cache.convertedNodes.get(
+        node
+      ) as NodeType;
+      // return deep copy of node so modifications don't effect referenced to the original
+      return JSON.parse(JSON.stringify(cachedType));
     }
 
     const convertedNode = this.tsNodeToType(node);

--- a/xlr/converters/src/xlr-to-ts.ts
+++ b/xlr/converters/src/xlr-to-ts.ts
@@ -96,7 +96,7 @@ export class TSWriter {
               this.context.factory.createIdentifier(refName),
               type.extends.genericArguments
                 ? (type.extends.genericArguments.map((node) =>
-                    this.createLiteralTypeNode(node)
+                    this.convertTypeNode(node)
                   ) as any)
                 : undefined
             ),

--- a/xlr/converters/src/xlr-to-ts.ts
+++ b/xlr/converters/src/xlr-to-ts.ts
@@ -375,7 +375,6 @@ export class TSWriter {
           undefined, // modifiers
           [
             this.context.factory.createParameterDeclaration(
-              undefined, // decorators
               undefined, // modifiers
               undefined, // dotdotdot token
               'key',

--- a/xlr/sdk/BUILD
+++ b/xlr/sdk/BUILD
@@ -16,6 +16,6 @@ javascript_pipeline(
         "@npm//typescript"
     ],
     test_data = [
-        "//common:static_xlrs"
+        "//common:@player-tools/static-xlrs",
     ]
 )

--- a/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
+++ b/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
@@ -465,13 +465,11 @@ exports[`Export Test Exports Typescript Types With Filters 1`] = `
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"input\\";
+export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
+    /** Asset container for a note. */
+    note?: AssetWrapper<AnyTextAsset>;
     /** The location in the data-model to store the data */
     binding: Binding;
     /** Optional additional data */
@@ -479,13 +477,8 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> {
         /** Additional data to beacon when this input changes */
         beacon?: string | Record<string, any>;
     };
-    [key: string]: unknown;
 }
-export interface TextAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"text\\";
+export interface TextAsset extends Asset<'text'> {
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -497,7 +490,7 @@ export interface TextAsset {
         [key: string]: unknown;
     } | {
         /** The link type denotes this as a link */
-        type: \\"link\\";
+        type: 'link';
         /** An optional expression to run before the link is opened */
         exp?: Expression;
         /** metaData about the link's target */
@@ -508,18 +501,13 @@ export interface TextAsset {
             'mime-type'?: string;
         };
     }>;
-    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"action\\";
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -535,13 +523,8 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
         /** Force transition to the next view without checking for validation */
         skipValidation?: boolean;
     };
-    [key: string]: unknown;
 }
-export interface InfoAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"info\\";
+export interface InfoAsset extends Asset<'info'> {
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -550,16 +533,12 @@ export interface InfoAsset {
     primaryInfo?: AssetWrapper;
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
-    [key: string]: unknown;
 }
-export interface CollectionAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"collection\\";
+export interface CollectionAsset extends Asset<'collection'> {
+    /** An optional label to title the collection */
+    label?: AssetWrapper;
     /** The string value to show */
-    values: Array<AssetWrapper>;
-    [key: string]: unknown;
+    values?: Array<AssetWrapper>;
 }"
 `;
 
@@ -570,13 +549,11 @@ exports[`Export Test Exports Typescript Types With Transforms 1`] = `
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"input\\";
+export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
+    /** Asset container for a note. */
+    note?: AssetWrapper<AnyTextAsset>;
     /** The location in the data-model to store the data */
     binding: Binding;
     /** Optional additional data */
@@ -585,13 +562,8 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> {
         beacon?: string | Record<string, any>;
     };
     transformed?: true;
-    [key: string]: unknown;
 }
-export interface TextAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"text\\";
+export interface TextAsset extends Asset<'text'> {
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -603,7 +575,7 @@ export interface TextAsset {
         [key: string]: unknown;
     } | {
         /** The link type denotes this as a link */
-        type: \\"link\\";
+        type: 'link';
         /** An optional expression to run before the link is opened */
         exp?: Expression;
         /** metaData about the link's target */
@@ -615,18 +587,13 @@ export interface TextAsset {
         };
     }>;
     transformed?: true;
-    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"action\\";
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -643,13 +610,8 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
         skipValidation?: boolean;
     };
     transformed?: true;
-    [key: string]: unknown;
 }
-export interface InfoAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"info\\";
+export interface InfoAsset extends Asset<'info'> {
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -659,17 +621,13 @@ export interface InfoAsset {
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
     transformed?: true;
-    [key: string]: unknown;
 }
-export interface CollectionAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"collection\\";
+export interface CollectionAsset extends Asset<'collection'> {
+    /** An optional label to title the collection */
+    label?: AssetWrapper;
     /** The string value to show */
-    values: Array<AssetWrapper>;
+    values?: Array<AssetWrapper>;
     transformed?: true;
-    [key: string]: unknown;
 }"
 `;
 
@@ -680,13 +638,11 @@ exports[`Export Test Exports Typescript types 1`] = `
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"input\\";
+export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
+    /** Asset container for a note. */
+    note?: AssetWrapper<AnyTextAsset>;
     /** The location in the data-model to store the data */
     binding: Binding;
     /** Optional additional data */
@@ -694,13 +650,8 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> {
         /** Additional data to beacon when this input changes */
         beacon?: string | Record<string, any>;
     };
-    [key: string]: unknown;
 }
-export interface TextAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"text\\";
+export interface TextAsset extends Asset<'text'> {
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -712,7 +663,7 @@ export interface TextAsset {
         [key: string]: unknown;
     } | {
         /** The link type denotes this as a link */
-        type: \\"link\\";
+        type: 'link';
         /** An optional expression to run before the link is opened */
         exp?: Expression;
         /** metaData about the link's target */
@@ -723,18 +674,13 @@ export interface TextAsset {
             'mime-type'?: string;
         };
     }>;
-    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"action\\";
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -750,13 +696,8 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
         /** Force transition to the next view without checking for validation */
         skipValidation?: boolean;
     };
-    [key: string]: unknown;
 }
-export interface InfoAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"info\\";
+export interface InfoAsset extends Asset<'info'> {
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -765,15 +706,130 @@ export interface InfoAsset {
     primaryInfo?: AssetWrapper;
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
-    [key: string]: unknown;
 }
-export interface CollectionAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: \\"collection\\";
+export interface CollectionAsset extends Asset<'collection'> {
+    /** An optional label to title the collection */
+    label?: AssetWrapper;
     /** The string value to show */
-    values: Array<AssetWrapper>;
-    [key: string]: unknown;
+    values?: Array<AssetWrapper>;
 }"
+`;
+
+exports[`Object Recall Working Test 1`] = `
+Object {
+  "additionalProperties": Object {
+    "type": "unknown",
+  },
+  "description": "Effective type combining Asset and InputAsset",
+  "genericTokens": Array [
+    Object {
+      "constraints": Object {
+        "type": "string",
+      },
+      "default": Object {
+        "type": "string",
+      },
+      "symbol": "T",
+    },
+  ],
+  "name": "InputAsset",
+  "properties": Object {
+    "binding": Object {
+      "node": Object {
+        "description": "The location in the data-model to store the data",
+        "ref": "Binding",
+        "title": "InputAsset.binding",
+        "type": "ref",
+      },
+      "required": true,
+    },
+    "id": Object {
+      "node": Object {
+        "description": "Each asset requires a unique id per view",
+        "title": "Asset.id",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "label": Object {
+      "node": Object {
+        "description": "Asset container for a field label.",
+        "genericArguments": Array [
+          Object {
+            "ref": "AnyTextAsset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyTextAsset>",
+        "title": "InputAsset.label",
+        "type": "ref",
+      },
+      "required": false,
+    },
+    "metaData": Object {
+      "node": Object {
+        "additionalProperties": false,
+        "description": "Optional additional data",
+        "properties": Object {
+          "beacon": Object {
+            "node": Object {
+              "description": "Additional data to beacon when this input changes",
+              "name": "BeaconDataType",
+              "or": Array [
+                Object {
+                  "title": "BeaconDataType",
+                  "type": "string",
+                },
+                Object {
+                  "keyType": Object {
+                    "type": "string",
+                  },
+                  "title": "BeaconDataType",
+                  "type": "record",
+                  "valueType": Object {
+                    "type": "any",
+                  },
+                },
+              ],
+              "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/node_modules/@player-ui/beacon-plugin/dist/index.d.ts",
+              "title": "InputAsset.metaData.beacon",
+              "type": "or",
+            },
+            "required": false,
+          },
+        },
+        "title": "InputAsset.metaData",
+        "type": "object",
+      },
+      "required": false,
+    },
+    "note": Object {
+      "node": Object {
+        "description": "Asset container for a note.",
+        "genericArguments": Array [
+          Object {
+            "ref": "AnyTextAsset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyTextAsset>",
+        "title": "InputAsset.note",
+        "type": "ref",
+      },
+      "required": false,
+    },
+    "type": Object {
+      "node": Object {
+        "const": "input",
+        "description": "The asset type determines the semantics of how a user interacts with a page",
+        "title": "Asset.type",
+        "type": "string",
+      },
+      "required": true,
+    },
+  },
+  "source": "core/types/src/index.ts",
+  "title": "Asset",
+  "type": "object",
+}
 `;

--- a/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
+++ b/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
@@ -828,7 +828,7 @@ Object {
       "required": true,
     },
   },
-  "source": "core/types/src/index.ts",
+  "source": "src/index.ts",
   "title": "Asset",
   "type": "object",
 }

--- a/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
+++ b/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
@@ -1,6 +1,464 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Basic Validation Working Test 1`] = `
+exports[`Basic Validation Basic Validation By Name 1`] = `
+Array [
+  Object {
+    "message": "Expected type 'string' but got 'number'",
+    "node": Object {
+      "children": Array [
+        Object {
+          "length": 4,
+          "offset": 13,
+          "parent": [Circular],
+          "type": "string",
+          "value": "id",
+        },
+        Object {
+          "length": 1,
+          "offset": 19,
+          "parent": [Circular],
+          "type": "number",
+          "value": 1,
+        },
+      ],
+      "colonOffset": 17,
+      "length": 7,
+      "offset": 13,
+      "parent": Object {
+        "children": Array [
+          [Circular],
+          Object {
+            "children": Array [
+              Object {
+                "length": 6,
+                "offset": 28,
+                "parent": [Circular],
+                "type": "string",
+                "value": "type",
+              },
+              Object {
+                "length": 7,
+                "offset": 36,
+                "parent": [Circular],
+                "type": "string",
+                "value": "input",
+              },
+            ],
+            "colonOffset": 34,
+            "length": 15,
+            "offset": 28,
+            "parent": [Circular],
+            "type": "property",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "length": 9,
+                "offset": 51,
+                "parent": [Circular],
+                "type": "string",
+                "value": "binding",
+              },
+              Object {
+                "length": 11,
+                "offset": 62,
+                "parent": [Circular],
+                "type": "string",
+                "value": "some.data",
+              },
+            ],
+            "colonOffset": 60,
+            "length": 22,
+            "offset": 51,
+            "parent": [Circular],
+            "type": "property",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "length": 7,
+                        "offset": 100,
+                        "parent": [Circular],
+                        "type": "string",
+                        "value": "asset",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "children": Array [
+                              Object {
+                                "length": 7,
+                                "offset": 121,
+                                "parent": [Circular],
+                                "type": "string",
+                                "value": "value",
+                              },
+                              Object {
+                                "length": 17,
+                                "offset": 130,
+                                "parent": [Circular],
+                                "type": "string",
+                                "value": "{{input.label}}",
+                              },
+                            ],
+                            "colonOffset": 128,
+                            "length": 26,
+                            "offset": 121,
+                            "parent": [Circular],
+                            "type": "property",
+                          },
+                        ],
+                        "length": 48,
+                        "offset": 109,
+                        "parent": [Circular],
+                        "type": "object",
+                      },
+                    ],
+                    "colonOffset": 107,
+                    "length": 57,
+                    "offset": 100,
+                    "parent": [Circular],
+                    "type": "property",
+                  },
+                ],
+                "length": 75,
+                "offset": 90,
+                "parent": [Circular],
+                "type": "object",
+              },
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": [Circular],
+            "type": "property",
+          },
+        ],
+        "length": 165,
+        "offset": 5,
+        "type": "object",
+      },
+      "type": "property",
+    },
+    "type": "type",
+  },
+  Object {
+    "message": "Property 'id' missing from type 'Asset'",
+    "node": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "length": 7,
+              "offset": 121,
+              "parent": [Circular],
+              "type": "string",
+              "value": "value",
+            },
+            Object {
+              "length": 17,
+              "offset": 130,
+              "parent": [Circular],
+              "type": "string",
+              "value": "{{input.label}}",
+            },
+          ],
+          "colonOffset": 128,
+          "length": 26,
+          "offset": 121,
+          "parent": [Circular],
+          "type": "property",
+        },
+      ],
+      "length": 48,
+      "offset": 109,
+      "parent": Object {
+        "children": Array [
+          Object {
+            "length": 7,
+            "offset": 100,
+            "parent": [Circular],
+            "type": "string",
+            "value": "asset",
+          },
+          [Circular],
+        ],
+        "colonOffset": 107,
+        "length": 57,
+        "offset": 100,
+        "parent": Object {
+          "children": Array [
+            [Circular],
+          ],
+          "length": 75,
+          "offset": 90,
+          "parent": Object {
+            "children": Array [
+              Object {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              [Circular],
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "length": 4,
+                      "offset": 13,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "id",
+                    },
+                    Object {
+                      "length": 1,
+                      "offset": 19,
+                      "parent": [Circular],
+                      "type": "number",
+                      "value": 1,
+                    },
+                  ],
+                  "colonOffset": 17,
+                  "length": 7,
+                  "offset": 13,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "length": 6,
+                      "offset": 28,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "type",
+                    },
+                    Object {
+                      "length": 7,
+                      "offset": 36,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "input",
+                    },
+                  ],
+                  "colonOffset": 34,
+                  "length": 15,
+                  "offset": 28,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "length": 9,
+                      "offset": 51,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "binding",
+                    },
+                    Object {
+                      "length": 11,
+                      "offset": 62,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "some.data",
+                    },
+                  ],
+                  "colonOffset": 60,
+                  "length": 22,
+                  "offset": 51,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                [Circular],
+              ],
+              "length": 165,
+              "offset": 5,
+              "type": "object",
+            },
+            "type": "property",
+          },
+          "type": "object",
+        },
+        "type": "property",
+      },
+      "type": "object",
+    },
+    "type": "missing",
+  },
+  Object {
+    "message": "Property 'type' missing from type 'Asset'",
+    "node": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "length": 7,
+              "offset": 121,
+              "parent": [Circular],
+              "type": "string",
+              "value": "value",
+            },
+            Object {
+              "length": 17,
+              "offset": 130,
+              "parent": [Circular],
+              "type": "string",
+              "value": "{{input.label}}",
+            },
+          ],
+          "colonOffset": 128,
+          "length": 26,
+          "offset": 121,
+          "parent": [Circular],
+          "type": "property",
+        },
+      ],
+      "length": 48,
+      "offset": 109,
+      "parent": Object {
+        "children": Array [
+          Object {
+            "length": 7,
+            "offset": 100,
+            "parent": [Circular],
+            "type": "string",
+            "value": "asset",
+          },
+          [Circular],
+        ],
+        "colonOffset": 107,
+        "length": 57,
+        "offset": 100,
+        "parent": Object {
+          "children": Array [
+            [Circular],
+          ],
+          "length": 75,
+          "offset": 90,
+          "parent": Object {
+            "children": Array [
+              Object {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              [Circular],
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "length": 4,
+                      "offset": 13,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "id",
+                    },
+                    Object {
+                      "length": 1,
+                      "offset": 19,
+                      "parent": [Circular],
+                      "type": "number",
+                      "value": 1,
+                    },
+                  ],
+                  "colonOffset": 17,
+                  "length": 7,
+                  "offset": 13,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "length": 6,
+                      "offset": 28,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "type",
+                    },
+                    Object {
+                      "length": 7,
+                      "offset": 36,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "input",
+                    },
+                  ],
+                  "colonOffset": 34,
+                  "length": 15,
+                  "offset": 28,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "length": 9,
+                      "offset": 51,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "binding",
+                    },
+                    Object {
+                      "length": 11,
+                      "offset": 62,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "some.data",
+                    },
+                  ],
+                  "colonOffset": 60,
+                  "length": 22,
+                  "offset": 51,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                [Circular],
+              ],
+              "length": 165,
+              "offset": 5,
+              "type": "object",
+            },
+            "type": "property",
+          },
+          "type": "object",
+        },
+        "type": "property",
+      },
+      "type": "object",
+    },
+    "type": "missing",
+  },
+]
+`;
+
+exports[`Basic Validation Basic Validation By Type 1`] = `
 Array [
   Object {
     "message": "Expected type 'string' but got 'number'",
@@ -717,30 +1175,19 @@ export interface CollectionAsset extends Asset<'collection'> {
 
 exports[`Object Recall Processed 1`] = `
 Object {
-  "additionalProperties": false,
-  "description": "This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
-Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.",
-  "extends": Object {
-    "genericArguments": Array [
-      Object {
-        "const": "input",
-        "type": "string",
-      },
-    ],
-    "ref": "Asset<'input'>",
-    "type": "ref",
+  "additionalProperties": Object {
+    "type": "unknown",
   },
+  "description": "Effective type combining Asset and InputAsset",
   "genericTokens": Array [
     Object {
       "constraints": Object {
-        "ref": "Asset",
-        "type": "ref",
+        "type": "string",
       },
       "default": Object {
-        "ref": "Asset",
-        "type": "ref",
+        "type": "string",
       },
-      "symbol": "AnyTextAsset",
+      "symbol": "T",
     },
   ],
   "name": "InputAsset",
@@ -751,6 +1198,14 @@ Players can get field type information from the 'schema' definition, thus to dec
         "ref": "Binding",
         "title": "InputAsset.binding",
         "type": "ref",
+      },
+      "required": true,
+    },
+    "id": Object {
+      "node": Object {
+        "description": "Each asset requires a unique id per view",
+        "title": "Asset.id",
+        "type": "string",
       },
       "required": true,
     },
@@ -821,9 +1276,18 @@ Players can get field type information from the 'schema' definition, thus to dec
       },
       "required": false,
     },
+    "type": Object {
+      "node": Object {
+        "const": "input",
+        "description": "The asset type determines the semantics of how a user interacts with a page",
+        "title": "Asset.type",
+        "type": "string",
+      },
+      "required": true,
+    },
   },
-  "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/input/types.ts",
-  "title": "InputAsset",
+  "source": "src/index.ts",
+  "title": "Asset",
   "type": "object",
 }
 `;

--- a/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
+++ b/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
@@ -715,21 +715,32 @@ export interface CollectionAsset extends Asset<'collection'> {
 }"
 `;
 
-exports[`Object Recall Working Test 1`] = `
+exports[`Object Recall Processed 1`] = `
 Object {
-  "additionalProperties": Object {
-    "type": "unknown",
+  "additionalProperties": false,
+  "description": "This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
+Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.",
+  "extends": Object {
+    "genericArguments": Array [
+      Object {
+        "const": "input",
+        "type": "string",
+      },
+    ],
+    "ref": "Asset<'input'>",
+    "type": "ref",
   },
-  "description": "Effective type combining Asset and InputAsset",
   "genericTokens": Array [
     Object {
       "constraints": Object {
-        "type": "string",
+        "ref": "Asset",
+        "type": "ref",
       },
       "default": Object {
-        "type": "string",
+        "ref": "Asset",
+        "type": "ref",
       },
-      "symbol": "T",
+      "symbol": "AnyTextAsset",
     },
   ],
   "name": "InputAsset",
@@ -740,14 +751,6 @@ Object {
         "ref": "Binding",
         "title": "InputAsset.binding",
         "type": "ref",
-      },
-      "required": true,
-    },
-    "id": Object {
-      "node": Object {
-        "description": "Each asset requires a unique id per view",
-        "title": "Asset.id",
-        "type": "string",
       },
       "required": true,
     },
@@ -818,18 +821,122 @@ Object {
       },
       "required": false,
     },
-    "type": Object {
-      "node": Object {
+  },
+  "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/input/types.ts",
+  "title": "InputAsset",
+  "type": "object",
+}
+`;
+
+exports[`Object Recall Raw 1`] = `
+Object {
+  "additionalProperties": false,
+  "description": "This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
+Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.",
+  "extends": Object {
+    "genericArguments": Array [
+      Object {
         "const": "input",
-        "description": "The asset type determines the semantics of how a user interacts with a page",
-        "title": "Asset.type",
         "type": "string",
+      },
+    ],
+    "ref": "Asset<'input'>",
+    "type": "ref",
+  },
+  "genericTokens": Array [
+    Object {
+      "constraints": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "default": Object {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "symbol": "AnyTextAsset",
+    },
+  ],
+  "name": "InputAsset",
+  "properties": Object {
+    "binding": Object {
+      "node": Object {
+        "description": "The location in the data-model to store the data",
+        "ref": "Binding",
+        "title": "InputAsset.binding",
+        "type": "ref",
       },
       "required": true,
     },
+    "label": Object {
+      "node": Object {
+        "description": "Asset container for a field label.",
+        "genericArguments": Array [
+          Object {
+            "ref": "AnyTextAsset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyTextAsset>",
+        "title": "InputAsset.label",
+        "type": "ref",
+      },
+      "required": false,
+    },
+    "metaData": Object {
+      "node": Object {
+        "additionalProperties": false,
+        "description": "Optional additional data",
+        "properties": Object {
+          "beacon": Object {
+            "node": Object {
+              "description": "Additional data to beacon when this input changes",
+              "name": "BeaconDataType",
+              "or": Array [
+                Object {
+                  "title": "BeaconDataType",
+                  "type": "string",
+                },
+                Object {
+                  "keyType": Object {
+                    "type": "string",
+                  },
+                  "title": "BeaconDataType",
+                  "type": "record",
+                  "valueType": Object {
+                    "type": "any",
+                  },
+                },
+              ],
+              "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/node_modules/@player-ui/beacon-plugin/dist/index.d.ts",
+              "title": "InputAsset.metaData.beacon",
+              "type": "or",
+            },
+            "required": false,
+          },
+        },
+        "title": "InputAsset.metaData",
+        "type": "object",
+      },
+      "required": false,
+    },
+    "note": Object {
+      "node": Object {
+        "description": "Asset container for a note.",
+        "genericArguments": Array [
+          Object {
+            "ref": "AnyTextAsset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyTextAsset>",
+        "title": "InputAsset.note",
+        "type": "ref",
+      },
+      "required": false,
+    },
   },
-  "source": "src/index.ts",
-  "title": "Asset",
+  "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/181/execroot/player/plugins/reference-assets/core/src/assets/input/types.ts",
+  "title": "InputAsset",
   "type": "object",
 }
 `;

--- a/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
+++ b/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
@@ -923,7 +923,11 @@ exports[`Export Test Exports Typescript Types With Filters 1`] = `
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
+export interface InputAsset<AnyTextAsset extends Asset = Asset> {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'input';
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
     /** Asset container for a note. */
@@ -935,8 +939,13 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'i
         /** Additional data to beacon when this input changes */
         beacon?: string | Record<string, any>;
     };
+    [key: string]: unknown;
 }
-export interface TextAsset extends Asset<'text'> {
+export interface TextAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'text';
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -959,13 +968,18 @@ export interface TextAsset extends Asset<'text'> {
             'mime-type'?: string;
         };
     }>;
+    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'action';
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -981,8 +995,13 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'
         /** Force transition to the next view without checking for validation */
         skipValidation?: boolean;
     };
+    [key: string]: unknown;
 }
-export interface InfoAsset extends Asset<'info'> {
+export interface InfoAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'info';
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -991,12 +1010,18 @@ export interface InfoAsset extends Asset<'info'> {
     primaryInfo?: AssetWrapper;
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
+    [key: string]: unknown;
 }
-export interface CollectionAsset extends Asset<'collection'> {
+export interface CollectionAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'collection';
     /** An optional label to title the collection */
     label?: AssetWrapper;
     /** The string value to show */
     values?: Array<AssetWrapper>;
+    [key: string]: unknown;
 }"
 `;
 
@@ -1007,7 +1032,11 @@ exports[`Export Test Exports Typescript Types With Transforms 1`] = `
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
+export interface InputAsset<AnyTextAsset extends Asset = Asset> {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'input';
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
     /** Asset container for a note. */
@@ -1020,8 +1049,13 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'i
         beacon?: string | Record<string, any>;
     };
     transformed?: true;
+    [key: string]: unknown;
 }
-export interface TextAsset extends Asset<'text'> {
+export interface TextAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'text';
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -1045,13 +1079,18 @@ export interface TextAsset extends Asset<'text'> {
         };
     }>;
     transformed?: true;
+    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'action';
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -1068,8 +1107,13 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'
         skipValidation?: boolean;
     };
     transformed?: true;
+    [key: string]: unknown;
 }
-export interface InfoAsset extends Asset<'info'> {
+export interface InfoAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'info';
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -1079,13 +1123,19 @@ export interface InfoAsset extends Asset<'info'> {
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
     transformed?: true;
+    [key: string]: unknown;
 }
-export interface CollectionAsset extends Asset<'collection'> {
+export interface CollectionAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'collection';
     /** An optional label to title the collection */
     label?: AssetWrapper;
     /** The string value to show */
     values?: Array<AssetWrapper>;
     transformed?: true;
+    [key: string]: unknown;
 }"
 `;
 
@@ -1096,7 +1146,11 @@ exports[`Export Test Exports Typescript types 1`] = `
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
+export interface InputAsset<AnyTextAsset extends Asset = Asset> {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'input';
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
     /** Asset container for a note. */
@@ -1108,8 +1162,13 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'i
         /** Additional data to beacon when this input changes */
         beacon?: string | Record<string, any>;
     };
+    [key: string]: unknown;
 }
-export interface TextAsset extends Asset<'text'> {
+export interface TextAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'text';
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -1132,13 +1191,18 @@ export interface TextAsset extends Asset<'text'> {
             'mime-type'?: string;
         };
     }>;
+    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'action';
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -1154,8 +1218,13 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'
         /** Force transition to the next view without checking for validation */
         skipValidation?: boolean;
     };
+    [key: string]: unknown;
 }
-export interface InfoAsset extends Asset<'info'> {
+export interface InfoAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'info';
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -1164,12 +1233,1022 @@ export interface InfoAsset extends Asset<'info'> {
     primaryInfo?: AssetWrapper;
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
+    [key: string]: unknown;
 }
-export interface CollectionAsset extends Asset<'collection'> {
+export interface CollectionAsset {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: 'collection';
     /** An optional label to title the collection */
     label?: AssetWrapper;
     /** The string value to show */
     values?: Array<AssetWrapper>;
+    [key: string]: unknown;
+}
+/** An asset is the smallest unit of user interaction in a player view */
+export interface Asset<T extends string = string> {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: T;
+    [key: string]: unknown;
+}
+/** An asset that contains a Binding. */
+export interface AssetBinding<T extends string = string> {
+    /** Each asset requires a unique id per view */
+    id: string;
+    /** The asset type determines the semantics of how a user interacts with a page */
+    type: T;
+    /** A binding that points to somewhere in the data model */
+    binding: Binding;
+    [key: string]: unknown;
+}
+/** A single case statement to use in a switch */
+export interface SwitchCase<T extends Asset = Asset> {
+    /** The Asset to use if this case is applicable */
+    asset: T;
+    /** An expression to execute to determine if this case applies */
+    case: Expression | true;
+}
+/** A switch can replace an asset with the applicable case on first render */
+export type Switch<T extends Asset = Asset> = Array<{
+    /** The Asset to use if this case is applicable */
+    asset: T;
+    /** An expression to execute to determine if this case applies */
+    case: Expression | true;
+}>;
+/** An object that contains an asset */
+export interface AssetWrapper<T extends Asset = Asset> {
+    /** An asset instance */
+    asset: T;
+    [key: string]: unknown;
+}
+export type AssetWrapperOrSwitch<T extends Asset = Asset> = (AssetWrapper<T> & {
+    /** The dynamicSwitch property can't exist at the same time as 'asset' */
+    dynamicSwitch?: never;
+    /** The staticSwitch property can't exist at the same time as 'asset' */
+    staticSwitch?: never;
+}) | ({
+    /** A static switch only evaluates the applicable base on first render of the view */
+    staticSwitch: Array<{
+        /** The Asset to use if this case is applicable */
+        asset: T;
+        /** An expression to execute to determine if this case applies */
+        case: Expression | true;
+    }>;
+} & {
+    /** The staticSwitch property can't exist at the same time as 'asset' */
+    asset?: never;
+    /** The staticSwitch property can't exist at the same time as 'dynamicSwitch' */
+    dynamicSwitch?: never;
+}) | ({
+    /** A dynamic switch re-evaluates the applicable case as data changes */
+    dynamicSwitch: Array<{
+        /** The Asset to use if this case is applicable */
+        asset: T;
+        /** An expression to execute to determine if this case applies */
+        case: Expression | true;
+    }>;
+} & {
+    /** The dynamicSwitch property can't exist at the same time as 'asset' */
+    asset?: never;
+    /** The dynamicSwitch property can't exist at the same time as 'staticSwitch' */
+    staticSwitch?: never;
+});
+export type AssetSwitch<T extends Asset = Asset> = {
+    /** A static switch only evaluates the applicable base on first render of the view */
+    staticSwitch: Array<{
+        /** The Asset to use if this case is applicable */
+        asset: T;
+        /** An expression to execute to determine if this case applies */
+        case: Expression | true;
+    }>;
+} | {
+    /** A dynamic switch re-evaluates the applicable case as data changes */
+    dynamicSwitch: Array<{
+        /** The Asset to use if this case is applicable */
+        asset: T;
+        /** An expression to execute to determine if this case applies */
+        case: Expression | true;
+    }>;
+};
+export interface StaticSwitch<T extends Asset = Asset> {
+    /** A static switch only evaluates the applicable base on first render of the view */
+    staticSwitch: Array<{
+        /** The Asset to use if this case is applicable */
+        asset: T;
+        /** An expression to execute to determine if this case applies */
+        case: Expression | true;
+    }>;
+}
+export interface DynamicSwitch<T extends Asset = Asset> {
+    /** A dynamic switch re-evaluates the applicable case as data changes */
+    dynamicSwitch: Array<{
+        /** The Asset to use if this case is applicable */
+        asset: T;
+        /** An expression to execute to determine if this case applies */
+        case: Expression | true;
+    }>;
+}
+/**
+ * Expressions are a specialized way of executing code.
+ * If the expression is a composite, the last expression executed is the return value
+*/
+export type Expression = string | Array<string>;
+export type ExpressionRef = \`@[\${string}]@\`;
+/** Bindings describe locations in the data model. */
+export type Binding = string;
+export type BindingRef = \`{{\${string}}}\`;
+/** The data-model is the location that all user data is stored */
+export type DataModel = Record<any, unknown>;
+/** The navigation section of the flow describes a State Machine for the user. */
+export type Navigation = {
+    /** The name of the Flow to begin on */
+    BEGIN: string;
+} & Record<string, string | {
+    /** The first state to kick off the state machine */
+    startState: string;
+    /** An optional expression to run when this Flow starts */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run when this Flow ends */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    [key: string]: undefined | string | Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    } | ({
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'VIEW';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /** A mapping of transition-name to FlowState name */
+        transitions: Record<string, string>;
+        /** An id corresponding to a view from the 'views' array */
+        ref: string;
+        /** View meta-properties */
+        attributes?: {
+            [key: string]: any;
+        };
+    } | {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'END';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /**
+         * A description of _how_ the flow ended.
+         * If this is a flow started from another flow, the outcome determines the flow transition
+        */
+        outcome: string;
+    } | {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'FLOW';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /** A mapping of transition-name to FlowState name */
+        transitions: Record<string, string>;
+        /** A reference to a FLOW id state to run */
+        ref: string;
+    } | {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'ACTION';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /**
+         * An expression to execute.
+         * The return value determines the transition to take
+        */
+        exp: Expression;
+        /** A mapping of transition-name to FlowState name */
+        transitions: Record<string, string>;
+    } | {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'EXTERNAL';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /** A mapping of transition-name to FlowState name */
+        transitions: Record<string, string>;
+        /** A reference for this external state */
+        ref: string;
+    });
+}>;
+/** An object with an expression in it */
+export interface ExpressionObject {
+    /** The expression to run */
+    exp?: Expression;
+}
+/** A state machine in the navigation */
+export interface NavigationFlow {
+    /** The first state to kick off the state machine */
+    startState: string;
+    /** An optional expression to run when this Flow starts */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run when this Flow ends */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    [key: string]: undefined | string | Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    } | ({
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'VIEW';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /** A mapping of transition-name to FlowState name */
+        transitions: Record<string, string>;
+        /** An id corresponding to a view from the 'views' array */
+        ref: string;
+        /** View meta-properties */
+        attributes?: {
+            [key: string]: any;
+        };
+    } | {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'END';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /**
+         * A description of _how_ the flow ended.
+         * If this is a flow started from another flow, the outcome determines the flow transition
+        */
+        outcome: string;
+    } | {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'FLOW';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /** A mapping of transition-name to FlowState name */
+        transitions: Record<string, string>;
+        /** A reference to a FLOW id state to run */
+        ref: string;
+    } | {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'ACTION';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /**
+         * An expression to execute.
+         * The return value determines the transition to take
+        */
+        exp: Expression;
+        /** A mapping of transition-name to FlowState name */
+        transitions: Record<string, string>;
+    } | {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'EXTERNAL';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /** A mapping of transition-name to FlowState name */
+        transitions: Record<string, string>;
+        /** A reference for this external state */
+        ref: string;
+    });
+}
+export type NavigationFlowTransition = Record<string, string>;
+/** The base representation of a state within a Flow */
+export interface NavigationBaseState<T extends string = any> {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: T;
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /**
+     * TS gets really confused with both the ActionState and the onStart state both declaring the \`exp\` property
+     * So this explicity says there should never be an exp prop on a state node that's not of type 'ACTION'
+    */
+    exp?: T extends T ? Expression : never;
+}
+/** A generic state that can transition to another state */
+export interface NavigationFlowTransitionableState<T extends string = any> {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: T;
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /**
+     * TS gets really confused with both the ActionState and the onStart state both declaring the \`exp\` property
+     * So this explicity says there should never be an exp prop on a state node that's not of type 'ACTION'
+    */
+    exp?: T extends T ? Expression : never;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+}
+/** A state representing a view */
+export interface NavigationFlowViewState {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'VIEW';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    exp?: never;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+    /** An id corresponding to a view from the 'views' array */
+    ref: string;
+    /** View meta-properties */
+    attributes?: {
+        [key: string]: any;
+    };
+}
+/** An END state of the flow. */
+export interface NavigationFlowEndState {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'END';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    exp?: never;
+    /**
+     * A description of _how_ the flow ended.
+     * If this is a flow started from another flow, the outcome determines the flow transition
+    */
+    outcome: string;
+}
+/** Action states execute an expression to determine the next state to transition to */
+export interface NavigationFlowActionState {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'ACTION';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /**
+     * An expression to execute.
+     * The return value determines the transition to take
+    */
+    exp: Expression;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+}
+/**
+ * External Flow states represent states in the FSM that can't be resolved internally in Player.
+ * The flow will wait for the embedded application to manage moving to the next state via a transition
+*/
+export interface NavigationFlowExternalState {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'EXTERNAL';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    exp?: never;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+    /** A reference for this external state */
+    ref: string;
+}
+export interface NavigationFlowFlowState {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'FLOW';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    exp?: never;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+    /** A reference to a FLOW id state to run */
+    ref: string;
+}
+export type NavigationFlowState = {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'VIEW';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    exp?: never;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+    /** An id corresponding to a view from the 'views' array */
+    ref: string;
+    /** View meta-properties */
+    attributes?: {
+        [key: string]: any;
+    };
+} | {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'END';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    exp?: never;
+    /**
+     * A description of _how_ the flow ended.
+     * If this is a flow started from another flow, the outcome determines the flow transition
+    */
+    outcome: string;
+} | {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'FLOW';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    exp?: never;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+    /** A reference to a FLOW id state to run */
+    ref: string;
+} | {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'ACTION';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /**
+     * An expression to execute.
+     * The return value determines the transition to take
+    */
+    exp: Expression;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+} | {
+    /** Add comments that will not be processing, but are useful for code explanation */
+    _comment?: string;
+    /** A property to determine the type of state this is */
+    state_type: 'EXTERNAL';
+    /** An optional expression to run when this view renders */
+    onStart?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    /** An optional expression to run before view transition */
+    onEnd?: Expression | {
+        /** The expression to run */
+        exp?: Expression;
+    };
+    exp?: never;
+    /** A mapping of transition-name to FlowState name */
+    transitions: Record<string, string>;
+    /** A reference for this external state */
+    ref: string;
+};
+/** The data at the end of a flow */
+export interface FlowResult {
+    /** The outcome describes _how_ the flow ended (forwards, backwards, etc) */
+    endState: {
+        /** Add comments that will not be processing, but are useful for code explanation */
+        _comment?: string;
+        /** A property to determine the type of state this is */
+        state_type: 'END';
+        /** An optional expression to run when this view renders */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run before view transition */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        exp?: never;
+        /**
+         * A description of _how_ the flow ended.
+         * If this is a flow started from another flow, the outcome determines the flow transition
+        */
+        outcome: string;
+    };
+    /** The serialized data-model */
+    data?: any;
+}
+/** Any object that contains 1 or more templates */
+export interface Templatable {
+    /** A list of templates to process for this node */
+    template?: Array<{
+        /** A pointer to the data-model containing an array of elements to map over */
+        data: Binding;
+        /**
+         * The template to iterate over using each value in the supplied template data.
+         * Any reference to _index_ is replaced with the current iteration index.
+        */
+        value: ValueType;
+        /** should the template be recomputed when data changes */
+        dynamic?: boolean;
+        /**
+         * A property on the parent object to store the new map under.
+         * If it already exists, values are appended to the end.
+        */
+        output: Key;
+    }>;
+}
+/** A template describes a mapping from a data array -> array of objects */
+export interface Template<ValueType extends any = unknown, Key extends string = string> {
+    /** A pointer to the data-model containing an array of elements to map over */
+    data: Binding;
+    /**
+     * The template to iterate over using each value in the supplied template data.
+     * Any reference to _index_ is replaced with the current iteration index.
+    */
+    value: ValueType;
+    /** should the template be recomputed when data changes */
+    dynamic?: boolean;
+    /**
+     * A property on the parent object to store the new map under.
+     * If it already exists, values are appended to the end.
+    */
+    output: Key;
+}
+export type View<T extends Asset = Asset> = unknown extends unknown ? T & {
+    /** Each view can optionally supply a list of validations to run against a particular view */
+    validation?: Array<{
+        /**
+         * The name of the referenced validation type
+         * This will be used to lookup the proper handler
+        */
+        type: string;
+        /** An optional means of overriding the default message if the validation is triggered */
+        message?: string;
+        /** An optional means of overriding the default severity of the validation if triggered */
+        severity?: 'error' | 'warning';
+        /** When to run this particular validation */
+        trigger?: 'navigation' | 'change' | 'load';
+        /** Cross-field references and validation must run against the default (deformatted) value */
+        dataTarget?: never;
+        /** Where the error should be displayed */
+        displayTarget?: 'page' | 'section' | 'field';
+        /** The binding to associate this validation with */
+        ref?: Binding;
+        [key: string]: unknown;
+    }>;
+} : T;
+/** The JSON payload for running Player */
+export interface Flow<T extends Asset = Asset> {
+    /** A unique identifier for the flow */
+    id: string;
+    /** A list of views (each with an ID) that can be shown to a user */
+    views?: Array<unknown extends unknown ? T & {
+        /** Each view can optionally supply a list of validations to run against a particular view */
+        validation?: Array<{
+            /**
+             * The name of the referenced validation type
+             * This will be used to lookup the proper handler
+            */
+            type: string;
+            /** An optional means of overriding the default message if the validation is triggered */
+            message?: string;
+            /** An optional means of overriding the default severity of the validation if triggered */
+            severity?: 'error' | 'warning';
+            /** When to run this particular validation */
+            trigger?: 'navigation' | 'change' | 'load';
+            /** Cross-field references and validation must run against the default (deformatted) value */
+            dataTarget?: never;
+            /** Where the error should be displayed */
+            displayTarget?: 'page' | 'section' | 'field';
+            /** The binding to associate this validation with */
+            ref?: Binding;
+            [key: string]: unknown;
+        }>;
+    } : T>;
+    /**
+     * The schema for the supplied (or referenced data).
+     * This is used for validation, formatting, etc
+    */
+    schema?: {
+        /** The ROOT object is the top level object to use */
+        ROOT: {
+            [key: string]: {
+                /** The reference of the base type to use */
+                type: string;
+                /** The referenced object represents an array rather than an object */
+                isArray?: boolean;
+                /**
+                 * Any additional validations that are associated with this property
+                 * These will add to any base validations associated with the \\"type\\"
+                */
+                validation?: Array<{
+                    /**
+                     * The name of the referenced validation type
+                     * This will be used to lookup the proper handler
+                    */
+                    type: string;
+                    /** An optional means of overriding the default message if the validation is triggered */
+                    message?: string;
+                    /** An optional means of overriding the default severity of the validation if triggered */
+                    severity?: 'error' | 'warning';
+                    /** When to run this particular validation */
+                    trigger?: 'navigation' | 'change' | 'load';
+                    /**
+                     * Each validation is passed the value of the data to run it's validation against.
+                     * By default, this is the value stored in the data-model (deformatted).
+                     * In the off chance you'd like this validator to run against the formatted value (the one the user sees), set this option
+                    */
+                    dataTarget?: 'formatted' | 'deformatted';
+                    /** Where the error should be displayed */
+                    displayTarget?: 'page' | 'section' | 'field';
+                    [key: string]: unknown;
+                }>;
+                /**
+                 * A reference to a specific data format to use.
+                 * If none is specified, will fallback to that of the base type
+                */
+                format?: {
+                    /** The name of the formatter (and de-formatter) to use */
+                    type: string;
+                    [key: string]: unknown;
+                };
+                /**
+                 * A default value for this property.
+                 * Any reads for this property will result in this default value being written to the model.
+                */
+                default?: T;
+                [key: string]: unknown;
+            };
+        };
+        [key: string]: {
+            [key: string]: {
+                /** The reference of the base type to use */
+                type: string;
+                /** The referenced object represents an array rather than an object */
+                isArray?: boolean;
+                /**
+                 * Any additional validations that are associated with this property
+                 * These will add to any base validations associated with the \\"type\\"
+                */
+                validation?: Array<{
+                    /**
+                     * The name of the referenced validation type
+                     * This will be used to lookup the proper handler
+                    */
+                    type: string;
+                    /** An optional means of overriding the default message if the validation is triggered */
+                    message?: string;
+                    /** An optional means of overriding the default severity of the validation if triggered */
+                    severity?: 'error' | 'warning';
+                    /** When to run this particular validation */
+                    trigger?: 'navigation' | 'change' | 'load';
+                    /**
+                     * Each validation is passed the value of the data to run it's validation against.
+                     * By default, this is the value stored in the data-model (deformatted).
+                     * In the off chance you'd like this validator to run against the formatted value (the one the user sees), set this option
+                    */
+                    dataTarget?: 'formatted' | 'deformatted';
+                    /** Where the error should be displayed */
+                    displayTarget?: 'page' | 'section' | 'field';
+                    [key: string]: unknown;
+                }>;
+                /**
+                 * A reference to a specific data format to use.
+                 * If none is specified, will fallback to that of the base type
+                */
+                format?: {
+                    /** The name of the formatter (and de-formatter) to use */
+                    type: string;
+                    [key: string]: unknown;
+                };
+                /**
+                 * A default value for this property.
+                 * Any reads for this property will result in this default value being written to the model.
+                */
+                default?: T;
+                [key: string]: unknown;
+            };
+        };
+    };
+    /** Any initial data that the flow can use */
+    data?: Record<any, unknown>;
+    /** A state machine to drive a user through the experience */
+    navigation: {
+        /** The name of the Flow to begin on */
+        BEGIN: string;
+    } & Record<string, string | {
+        /** The first state to kick off the state machine */
+        startState: string;
+        /** An optional expression to run when this Flow starts */
+        onStart?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        /** An optional expression to run when this Flow ends */
+        onEnd?: Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        };
+        [key: string]: undefined | string | Expression | {
+            /** The expression to run */
+            exp?: Expression;
+        } | ({
+            /** Add comments that will not be processing, but are useful for code explanation */
+            _comment?: string;
+            /** A property to determine the type of state this is */
+            state_type: 'VIEW';
+            /** An optional expression to run when this view renders */
+            onStart?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            /** An optional expression to run before view transition */
+            onEnd?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            exp?: never;
+            /** A mapping of transition-name to FlowState name */
+            transitions: Record<string, string>;
+            /** An id corresponding to a view from the 'views' array */
+            ref: string;
+            /** View meta-properties */
+            attributes?: {
+                [key: string]: any;
+            };
+        } | {
+            /** Add comments that will not be processing, but are useful for code explanation */
+            _comment?: string;
+            /** A property to determine the type of state this is */
+            state_type: 'END';
+            /** An optional expression to run when this view renders */
+            onStart?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            /** An optional expression to run before view transition */
+            onEnd?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            exp?: never;
+            /**
+             * A description of _how_ the flow ended.
+             * If this is a flow started from another flow, the outcome determines the flow transition
+            */
+            outcome: string;
+        } | {
+            /** Add comments that will not be processing, but are useful for code explanation */
+            _comment?: string;
+            /** A property to determine the type of state this is */
+            state_type: 'FLOW';
+            /** An optional expression to run when this view renders */
+            onStart?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            /** An optional expression to run before view transition */
+            onEnd?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            exp?: never;
+            /** A mapping of transition-name to FlowState name */
+            transitions: Record<string, string>;
+            /** A reference to a FLOW id state to run */
+            ref: string;
+        } | {
+            /** Add comments that will not be processing, but are useful for code explanation */
+            _comment?: string;
+            /** A property to determine the type of state this is */
+            state_type: 'ACTION';
+            /** An optional expression to run when this view renders */
+            onStart?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            /** An optional expression to run before view transition */
+            onEnd?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            /**
+             * An expression to execute.
+             * The return value determines the transition to take
+            */
+            exp: Expression;
+            /** A mapping of transition-name to FlowState name */
+            transitions: Record<string, string>;
+        } | {
+            /** Add comments that will not be processing, but are useful for code explanation */
+            _comment?: string;
+            /** A property to determine the type of state this is */
+            state_type: 'EXTERNAL';
+            /** An optional expression to run when this view renders */
+            onStart?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            /** An optional expression to run before view transition */
+            onEnd?: Expression | {
+                /** The expression to run */
+                exp?: Expression;
+            };
+            exp?: never;
+            /** A mapping of transition-name to FlowState name */
+            transitions: Record<string, string>;
+            /** A reference for this external state */
+            ref: string;
+        });
+    }>;
+    [key: string]: unknown;
 }"
 `;
 
@@ -1178,16 +2257,20 @@ Object {
   "additionalProperties": Object {
     "type": "unknown",
   },
-  "description": "Effective type combining Asset and InputAsset",
+  "description": "This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
+Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.",
+  "extends": undefined,
   "genericTokens": Array [
     Object {
       "constraints": Object {
-        "type": "string",
+        "ref": "Asset",
+        "type": "ref",
       },
       "default": Object {
-        "type": "string",
+        "ref": "Asset",
+        "type": "ref",
       },
-      "symbol": "T",
+      "symbol": "AnyTextAsset",
     },
   ],
   "name": "InputAsset",
@@ -1195,6 +2278,7 @@ Object {
     "binding": Object {
       "node": Object {
         "description": "The location in the data-model to store the data",
+        "genericArguments": undefined,
         "ref": "Binding",
         "title": "InputAsset.binding",
         "type": "ref",
@@ -1214,7 +2298,7 @@ Object {
         "description": "Asset container for a field label.",
         "genericArguments": Array [
           Object {
-            "ref": "AnyTextAsset",
+            "ref": "Asset",
             "type": "ref",
           },
         ],
@@ -1228,6 +2312,7 @@ Object {
       "node": Object {
         "additionalProperties": false,
         "description": "Optional additional data",
+        "extends": undefined,
         "properties": Object {
           "beacon": Object {
             "node": Object {
@@ -1266,7 +2351,7 @@ Object {
         "description": "Asset container for a note.",
         "genericArguments": Array [
           Object {
-            "ref": "AnyTextAsset",
+            "ref": "Asset",
             "type": "ref",
           },
         ],

--- a/xlr/sdk/src/__tests__/sdk.test.ts
+++ b/xlr/sdk/src/__tests__/sdk.test.ts
@@ -1,4 +1,4 @@
-import type { TransformFunction } from '@player-tools/xlr';
+import type { NamedType, TransformFunction } from '@player-tools/xlr';
 import { parseTree } from 'jsonc-parser';
 import typesManifest from '@player-tools/static-xlrs/static_xlrs/core/xlr/manifest';
 import pluginManifest from '@player-tools/static-xlrs/static_xlrs/plugin/xlr/manifest';
@@ -47,7 +47,7 @@ describe('Object Recall', () => {
     sdk.loadDefinitionsFromDisk('./common/static_xlrs/plugin', EXCLUDE);
     sdk.loadDefinitionsFromDisk('./common/static_xlrs/core');
 
-    expect(sdk.getType('InputAsset', { getRawType: true })).toMatchSnapshot();
+    expect(sdk.getType('InputAsset')).toMatchSnapshot();
   });
 
   it('Raw', () => {
@@ -60,7 +60,7 @@ describe('Object Recall', () => {
 });
 
 describe('Basic Validation', () => {
-  it('Working Test', () => {
+  it('Basic Validation By Name', () => {
     const mockAsset = parseTree(`
     {
       "id": 1,
@@ -78,6 +78,29 @@ describe('Basic Validation', () => {
     sdk.loadDefinitionsFromDisk('./common/static_xlrs/core');
 
     expect(sdk.validateByName('InputAsset', mockAsset)).toMatchSnapshot();
+  });
+
+  it('Basic Validation By Type', () => {
+    const mockAsset = parseTree(`
+    {
+      "id": 1,
+      "type": "input",
+      "binding": "some.data",
+      "label": {
+        "asset": {
+          "value": "{{input.label}}"
+        }
+      }
+    `);
+
+    const sdk = new XLRSDK();
+    sdk.loadDefinitionsFromDisk('./common/static_xlrs/plugin', EXCLUDE);
+    sdk.loadDefinitionsFromDisk('./common/static_xlrs/core');
+    const inputAsset = sdk.getType('InputAsset');
+    expect(inputAsset).toBeDefined();
+    expect(
+      sdk.validateByType(inputAsset as NamedType, mockAsset)
+    ).toMatchSnapshot();
   });
 });
 

--- a/xlr/sdk/src/__tests__/sdk.test.ts
+++ b/xlr/sdk/src/__tests__/sdk.test.ts
@@ -42,12 +42,20 @@ describe('Loading XLRs', () => {
 });
 
 describe('Object Recall', () => {
-  it('Working Test', () => {
+  it('Processed', () => {
     const sdk = new XLRSDK();
     sdk.loadDefinitionsFromDisk('./common/static_xlrs/plugin', EXCLUDE);
     sdk.loadDefinitionsFromDisk('./common/static_xlrs/core');
 
-    expect(sdk.getType('InputAsset')).toMatchSnapshot();
+    expect(sdk.getType('InputAsset', { getRawType: true })).toMatchSnapshot();
+  });
+
+  it('Raw', () => {
+    const sdk = new XLRSDK();
+    sdk.loadDefinitionsFromDisk('./common/static_xlrs/plugin', EXCLUDE);
+    sdk.loadDefinitionsFromDisk('./common/static_xlrs/core');
+
+    expect(sdk.getType('InputAsset', { getRawType: true })).toMatchSnapshot();
   });
 });
 

--- a/xlr/sdk/src/registry/basic-registry.ts
+++ b/xlr/sdk/src/registry/basic-registry.ts
@@ -73,7 +73,6 @@ export class BasicXLRRegistry implements XLRRegistry {
         });
       }
     });
-
     return validTypes.map((type) => this.get(type) as NamedType);
   }
 

--- a/xlr/sdk/src/sdk.ts
+++ b/xlr/sdk/src/sdk.ts
@@ -175,7 +175,7 @@ export class XLRSDK {
   }
 
   public validateByName(typeName: string, rootNode: Node) {
-    const xlr = this.getType(typeName);
+    const xlr = this.getType(typeName, { getRawType: true });
     if (!xlr) {
       throw new Error(
         `Type ${typeName} does not exist in registry, can't validate`

--- a/xlr/sdk/src/sdk.ts
+++ b/xlr/sdk/src/sdk.ts
@@ -43,6 +43,13 @@ export class XLRSDK {
     this.tsWriter = new TSWriter();
   }
 
+  /**
+   * Loads definitions from a path on the filesystem
+   *
+   * @param inputPath - path to the directory to load (above the xlr folder)
+   * @param filters - Any filters to apply when loading the types (a positive match will omit)
+   * @param transforms - any transforms to apply to the types being loaded
+   */
   public loadDefinitionsFromDisk(
     inputPath: string,
     filters?: Omit<Filters, 'pluginFilter'>,
@@ -77,20 +84,29 @@ export class XLRSDK {
               )
               .toString()
           );
-          let effectiveType = cType;
+          const effectiveType =
+            transforms?.reduce(
+              (typeAccumulator: NamedType<NodeType>, transformFn) =>
+                transformFn(
+                  typeAccumulator,
+                  capabilityName
+                ) as NamedType<NodeType>,
+              cType
+            ) ?? cType;
 
-          transforms?.forEach((transformFunction) => {
-            effectiveType = transformFunction(
-              effectiveType,
-              capabilityName
-            ) as NamedType;
-          });
           this.registry.add(effectiveType, manifest.pluginName, capabilityName);
         }
       });
     });
   }
 
+  /**
+   * Load definitions from a js/ts file in memory
+   *
+   * @param manifest - The imported XLR manifest module
+   * @param filters - Any filters to apply when loading the types (a positive match will omit)
+   * @param transforms - any transforms to apply to the types being loaded
+   */
   public async loadDefinitionsFromModule(
     manifest: TSManifest,
     filters?: Omit<Filters, 'pluginFilter'>,
@@ -108,13 +124,15 @@ export class XLRSDK {
           !filters?.typeFilter ||
           !extension.name.match(filters?.typeFilter)
         ) {
-          let effectiveType = extension;
-          transforms?.forEach((transformFunction) => {
-            effectiveType = transformFunction(
-              effectiveType,
-              capabilityName
-            ) as NamedType;
-          });
+          const effectiveType =
+            transforms?.reduce(
+              (typeAccumulator: NamedType<NodeType>, transformFn) =>
+                transformFn(
+                  typeAccumulator,
+                  capabilityName
+                ) as NamedType<NodeType>,
+              extension
+            ) ?? extension;
 
           this.registry.add(effectiveType, manifest.pluginName, capabilityName);
         }
@@ -122,6 +140,13 @@ export class XLRSDK {
     });
   }
 
+  /**
+   * Returns a Type that has been previously loaded
+   *
+   * @param id - Type to retrieve
+   * @param options - `GetTypeOptions`
+   * @returns `NamedType<NodeType>` | `undefined`
+   */
   public getType(
     id: string,
     options?: GetTypeOptions
@@ -136,18 +161,43 @@ export class XLRSDK {
     return fillInGenerics(type) as NamedType;
   }
 
+  /**
+   * Returns if a Type with `id` has been loaded into the DSK
+   *
+   * @param id - Type to retrieve
+   * @returns `boolean`
+   */
   public hasType(id: string) {
     return this.registry.has(id);
   }
 
+  /**
+   * Lists types that have been loaded into the SDK
+   *
+   * @param filters - Any filters to apply to the types returned (a positive match will omit)
+   * @returns `Array<NamedTypes>`
+   */
   public listTypes(filters?: Filters) {
     return this.registry.list(filters);
   }
 
+  /**
+   * Returns meta information around a registered type
+   *
+   * @param id - Name of Type to retrieve
+   * @returns `TypeMetaData` | `undefined`
+   */
   public getTypeInfo(id: string) {
     return this.registry.info(id);
   }
 
+  /**
+   * Validates if a JSONC Node follows the XLR Type registered under the `typeName` specified
+   *
+   * @param typeName - Registered XLR Type to use for validation
+   * @param rootNode - Node to validate
+   * @returns `Array<ValidationErrors>`
+   */
   public validateByName(typeName: string, rootNode: Node) {
     const xlr = this.getType(typeName, { getRawType: true });
     if (!xlr) {
@@ -159,6 +209,13 @@ export class XLRSDK {
     return this.validator.validateType(rootNode, xlr);
   }
 
+  /**
+   * Validates if a JSONC Node follows the supplied XLR Type
+   *
+   * @param type - Type to validate against
+   * @param rootNode - Node to validate
+   * @returns `Array<ValidationErrors>`
+   */
   public validateByType(type: NodeType, rootNode: Node) {
     return this.validator.validateType(rootNode, type);
   }
@@ -179,14 +236,17 @@ export class XLRSDK {
     transforms?: Array<TransformFunction>
   ): [string, string][] {
     const typesToExport = this.registry.list(filters).map((type) => {
-      let effectiveType = type;
-      effectiveType = this.resolveType(type);
-      transforms?.forEach((transformFunction) => {
-        effectiveType = transformFunction(
-          effectiveType,
-          this.registry.info(type.name)?.capability as string
-        ) as NamedType;
-      });
+      const resolvedType = this.resolveType(type);
+      const effectiveType =
+        transforms?.reduce(
+          (typeAccumulator: NamedType<NodeType>, transformFn) =>
+            transformFn(
+              typeAccumulator,
+              this.registry.info(type.name)?.capability as string
+            ) as NamedType<NodeType>,
+          resolvedType
+        ) ?? resolvedType;
+
       return effectiveType;
     });
 

--- a/xlr/sdk/src/sdk.ts
+++ b/xlr/sdk/src/sdk.ts
@@ -200,7 +200,7 @@ export class XLRSDK {
 
   private resolveType(type: NodeType) {
     return simpleTransformGenerator('object', 'any', (objectNode) => {
-      if (objectNode.type === 'object' && objectNode.extends) {
+      if (objectNode.extends) {
         const refName = objectNode.extends.ref.split('<')[0];
         let extendedType = this.getType(refName, { getRawType: true });
         if (!extendedType) {

--- a/xlr/sdk/src/utils.ts
+++ b/xlr/sdk/src/utils.ts
@@ -28,9 +28,9 @@ export function simpleTransformGenerator<
   ) => {
     // Run transform on base node before running on children
     if (capability === capabilityToTransform) {
-      const node = { ...n };
+      let node = { ...n };
       if (node.type === typeToTransform) {
-        return functionToRun(node as unknown as NodeTypeMap[T]);
+        node = functionToRun(node as unknown as NodeTypeMap[T]);
       }
 
       if (node.type === 'object') {

--- a/xlr/sdk/src/utils.ts
+++ b/xlr/sdk/src/utils.ts
@@ -6,6 +6,8 @@ import type {
   NodeTypeMap,
   TransformFunction,
   NodeType,
+  ObjectProperty,
+  RefNode,
 } from '@player-tools/xlr';
 
 /**
@@ -17,68 +19,127 @@ export function simpleTransformGenerator<
 >(
   typeToTransform: T,
   capabilityToTransform: string,
-  functionToRun: (input: NodeTypeMap[T]) => void
+  functionToRun: (input: NodeTypeMap[T]) => NodeTypeMap[T]
 ): TransformFunction {
   /** walker for an XLR tree to touch every node */
   const walker: TransformFunction = (
-    node: NamedType | NodeType,
+    n: NamedType | NodeType,
     capability: string
   ) => {
     // Run transform on base node before running on children
     if (capability === capabilityToTransform) {
+      const node = { ...n };
       if (node.type === typeToTransform) {
-        functionToRun(node as unknown as NodeTypeMap[T]);
+        return functionToRun(node as unknown as NodeTypeMap[T]);
       }
 
       if (node.type === 'object') {
-        if (node.extends) {
-          walker(node, capability);
-        }
+        const newObjectProperties: Record<string, ObjectProperty> = {};
 
         for (const key in node.properties) {
           const value = node.properties[key];
-          walker(value.node, capability);
+          newObjectProperties[key] = {
+            required: value.required,
+            node: walker(value.node, capability),
+          };
         }
 
-        if (node.additionalProperties) {
-          walker(node.additionalProperties, capability);
-        }
-      } else if (node.type === 'array') {
-        walker(node.elementType, capability);
-      } else if (node.type === 'and') {
-        node.and.forEach((element) => walker(element, capability));
-      } else if (node.type === 'or') {
-        node.or.forEach((element) => walker(element, capability));
-      } else if (node.type === 'ref') {
-        node.genericArguments?.forEach((element) =>
-          walker(element, capability)
-        );
-      } else if (node.type === 'tuple') {
-        if (node.additionalItems) {
-          walker(node.additionalItems, capability);
-        }
+        return {
+          ...node,
+          properties: { ...newObjectProperties },
+          extends: node.extends
+            ? (walker(node.extends, capability) as RefNode)
+            : undefined,
+          additionalProperties: node.additionalProperties
+            ? walker(node.additionalProperties, capability)
+            : false,
+        };
+      }
 
-        node.elementTypes.forEach((element) => walker(element, capability));
-      } else if (node.type === 'function') {
-        node.parameters.forEach((param) => {
-          walker(param.type, capability);
-          if (param.default) {
-            walker(param.default, capability);
-          }
-        });
-        if (node.returnType) {
-          walker(node.returnType, capability);
-        }
-      } else if (node.type === 'record') {
-        walker(node.keyType, capability);
-        walker(node.valueType, capability);
-      } else if (node.type === 'conditional') {
-        walker(node.check.left, capability);
-        walker(node.check.right, capability);
-        walker(node.value.true, capability);
-        walker(node.value.false, capability);
+      if (node.type === 'array') {
+        return {
+          ...node,
+          elementType: walker(node.elementType, capability),
+        };
+      }
+
+      if (node.type === 'and') {
+        return {
+          ...node,
+          and: node.and.map((element) => walker(element, capability)),
+        };
+      }
+
+      if (node.type === 'or') {
+        return {
+          ...node,
+          or: node.or.map((element) => walker(element, capability)),
+        };
+      }
+
+      if (node.type === 'ref') {
+        return {
+          ...node,
+          genericArguments: node.genericArguments?.map((arg) =>
+            walker(arg, capability)
+          ),
+        };
+      }
+
+      if (node.type === 'tuple') {
+        return {
+          ...node,
+          elementTypes: node.elementTypes.map((type) =>
+            walker(type, capability)
+          ),
+          additionalItems: node.additionalItems
+            ? walker(node.additionalItems, capability)
+            : false,
+        };
+      }
+
+      if (node.type === 'function') {
+        return {
+          ...node,
+          parameters: node.parameters.map((param) => {
+            return {
+              ...param,
+              type: walker(param.type, capability),
+              default: param.default
+                ? walker(param.default, capability)
+                : undefined,
+            };
+          }),
+          returnType: node.returnType
+            ? walker(node.returnType, capability)
+            : undefined,
+        };
+      }
+
+      if (node.type === 'record') {
+        return {
+          ...node,
+          keyType: walker(node.keyType, capability),
+          valueType: walker(node.valueType, capability),
+        };
+      }
+
+      if (node.type === 'conditional') {
+        return {
+          ...node,
+          check: {
+            left: walker(node.check.left, capability),
+            right: walker(node.check.left, capability),
+          },
+          value: {
+            true: walker(node.value.true, capability),
+            false: walker(node.value.false, capability),
+          },
+        };
       }
     }
+
+    return n;
   };
 
   return walker;

--- a/xlr/sdk/src/validator.ts
+++ b/xlr/sdk/src/validator.ts
@@ -122,14 +122,35 @@ export class XLRValidator {
         }
       }
     } else if (xlrNode.type === 'conditional') {
-      const resolvedType = resolveConditional(xlrNode);
-      if (resolvedType === xlrNode) {
+      // Resolve RefNodes in check conditions if needed
+      let { right, left } = xlrNode.check;
+
+      if (right.type === 'ref') {
+        right = this.getRefType(right);
+      }
+
+      if (left.type === 'ref') {
+        left = this.getRefType(left);
+      }
+
+      const resolvedXLRNode = {
+        ...xlrNode,
+        check: {
+          left,
+          right,
+        },
+      };
+
+      const resolvedConditional = resolveConditional(resolvedXLRNode);
+      if (resolvedConditional === resolvedXLRNode) {
         throw Error(
           `Unable to resolve conditional type at runtime: ${xlrNode.name}`
         );
       }
 
-      validationIssues.push(...this.validateType(rootNode, resolvedType));
+      validationIssues.push(
+        ...this.validateType(rootNode, resolvedConditional)
+      );
     } else {
       throw Error(`Unknown type ${xlrNode.type}`);
     }

--- a/xlr/sdk/src/validator.ts
+++ b/xlr/sdk/src/validator.ts
@@ -235,27 +235,22 @@ export class XLRValidator {
         }
 
         return typeof literalType.value === 'boolean';
-        break;
       case 'number':
         if (expectedType.const) {
           return expectedType.const === literalType.value;
         }
 
         return typeof literalType.value === 'number';
-        break;
       case 'string':
         if (expectedType.const) {
           return expectedType.const === literalType.value;
         }
 
         return typeof literalType.value === 'string';
-        break;
       case 'null':
         return literalType.value === 'null';
-        break;
       case 'never':
         return literalType === undefined;
-        break;
       case 'any':
         return literalType !== undefined;
       case 'unknown':

--- a/xlr/types/src/core.ts
+++ b/xlr/types/src/core.ts
@@ -90,6 +90,8 @@ export interface RefNode extends TypeNode<'ref'> {
   ref: string;
   /** Parameters to potentially fill in a generic when it is resolved. Position is preserved */
   genericArguments?: Array<NodeType>;
+  /** Optional property to access when the reference is resolved */
+  property?: string;
 }
 export type RefType = RefNode & Annotations;
 

--- a/xlr/types/src/utility.ts
+++ b/xlr/types/src/utility.ts
@@ -3,7 +3,7 @@ import type { NamedType, NodeType } from '.';
 export type TransformFunction = (
   input: NamedType<NodeType> | NodeType,
   capabilityType: string
-) => void;
+) => NamedType | NodeType;
 
 export interface Capability {
   /** Name of the capability that is provided to Player */

--- a/xlr/utils/src/__tests__/__snapshots__/validation-helpers.test.ts.snap
+++ b/xlr/utils/src/__tests__/__snapshots__/validation-helpers.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`computeEffectiveObject tests mixed test 1`] = `
+Object {
+  "additionalProperties": Object {
+    "type": "unknown",
+  },
+  "description": "Effective type combining object literal and object literal",
+  "name": "object literal & object literal",
+  "properties": Object {
+    "bar": Object {
+      "node": Object {
+        "type": "number",
+      },
+      "required": true,
+    },
+    "foo": Object {
+      "node": Object {
+        "type": "string",
+      },
+      "required": true,
+    },
+  },
+  "type": "object",
+}
+`;

--- a/xlr/utils/src/__tests__/__snapshots__/validation-helpers.test.ts.snap
+++ b/xlr/utils/src/__tests__/__snapshots__/validation-helpers.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     "type": "unknown",
   },
   "description": "Effective type combining object literal and object literal",
+  "genericTokens": Array [],
   "name": "object literal & object literal",
   "properties": Object {
     "bar": Object {

--- a/xlr/utils/src/__tests__/validation-helpers.test.ts
+++ b/xlr/utils/src/__tests__/validation-helpers.test.ts
@@ -1,0 +1,72 @@
+import type { ObjectType } from '@player-tools/xlr';
+import { computeEffectiveObject } from '../validation-helpers';
+
+describe('computeEffectiveObject tests', () => {
+  it('mixed test', () => {
+    const type1: ObjectType = {
+      type: 'object',
+      properties: {
+        foo: {
+          required: true,
+          node: {
+            type: 'string',
+          },
+        },
+      },
+      additionalProperties: false,
+    };
+
+    const type2: ObjectType = {
+      type: 'object',
+      properties: {
+        bar: {
+          required: true,
+          node: {
+            type: 'number',
+          },
+        },
+      },
+      additionalProperties: {
+        type: 'unknown',
+      },
+    };
+
+    expect(computeEffectiveObject(type1, type2)).toMatchSnapshot();
+  });
+
+  it('Error on property overlap', () => {
+    const type1: ObjectType = {
+      type: 'object',
+      properties: {
+        foo: {
+          required: true,
+          node: {
+            type: 'string',
+          },
+        },
+      },
+      additionalProperties: false,
+    };
+
+    const type2: ObjectType = {
+      type: 'object',
+      properties: {
+        foo: {
+          required: true,
+          node: {
+            type: 'number',
+          },
+        },
+      },
+      additionalProperties: {
+        type: 'unknown',
+      },
+    };
+
+    expect(() =>
+      computeEffectiveObject(type1, type2, true)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Can't compute effective type for object literal and object literal because of conflicting properties foo"`
+    );
+  });
+});

--- a/xlr/utils/src/test-helpers.ts
+++ b/xlr/utils/src/test-helpers.ts
@@ -15,11 +15,8 @@ export interface SetupReturnType {
 /**
  * Setups a virtual TS environment for tests
  */
-export async function setupTestEnv(
-  sourceCode: string,
-  mockFileName = 'filename.ts'
-) {
-  const fsMap = await tsvfs.createDefaultMapFromNodeModules({}, ts);
+export function setupTestEnv(sourceCode: string, mockFileName = 'filename.ts') {
+  const fsMap = tsvfs.createDefaultMapFromNodeModules({}, ts);
   fsMap.set(mockFileName, sourceCode);
 
   const system = tsvfs.createSystem(fsMap);

--- a/xlr/utils/src/ts-helpers.ts
+++ b/xlr/utils/src/ts-helpers.ts
@@ -20,8 +20,12 @@ export function tsStripOptionalType(node: ts.TypeNode): ts.TypeNode {
  * Returns if the top level declaration is exported
  */
 export function isExportedDeclaration(node: ts.Statement) {
-  return !!node.modifiers?.some(
-    (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+  const modifiers = ts.canHaveModifiers(node)
+    ? ts.getModifiers(node)
+    : undefined;
+  return (
+    modifiers &&
+    modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
   );
 }
 

--- a/xlr/utils/src/ts-helpers.ts
+++ b/xlr/utils/src/ts-helpers.ts
@@ -129,6 +129,7 @@ export function buildTemplateRegex(
 
 /**
  * Walks generics to fill in values from a combination of the default, constraint, and passed in map values
+ * TODO convert this to use simpleTransformGenerator
  */
 export function fillInGenerics(
   xlrNode: NodeType,

--- a/xlr/utils/src/type-checks.ts
+++ b/xlr/utils/src/type-checks.ts
@@ -90,7 +90,6 @@ export function isPrimitiveTypeNode(node: NodeType): node is PrimitiveTypes {
     node.type === 'number' ||
     node.type === 'boolean' ||
     node.type === 'null' ||
-    node.type === 'template' ||
     node.type === 'any' ||
     node.type === 'never' ||
     node.type === 'undefined' ||

--- a/xlr/utils/src/validation-helpers.ts
+++ b/xlr/utils/src/validation-helpers.ts
@@ -1,6 +1,12 @@
 import type { Node } from 'jsonc-parser';
-import type { ConditionalType, NodeType } from '@player-tools/xlr';
-import { isPrimitiveTypeNode } from './type-checks';
+import type {
+  ConditionalType,
+  NodeType,
+  ObjectType,
+  RefNode,
+} from '@player-tools/xlr';
+import { isGenericNodeType, isPrimitiveTypeNode } from './type-checks';
+import { fillInGenerics } from './ts-helpers';
 
 export interface PropertyNode {
   /** Equivalent Property Name */
@@ -85,4 +91,84 @@ export function resolveConditional(conditional: ConditionalType): NodeType {
 
   // unable to process return original
   return conditional;
+}
+
+/**
+ *
+ */
+export function resolveReferenceNode(
+  genericReference: RefNode,
+  typeToFill: NodeType
+): NodeType {
+  const genericArgs = genericReference.genericArguments;
+  const genericMap: Map<string, NodeType> = new Map();
+
+  // Compose first level generics here since `fillInGenerics` won't process them if a map is passed in
+  if (genericArgs && isGenericNodeType(typeToFill)) {
+    typeToFill.genericTokens.forEach((token, index) => {
+      genericMap.set(
+        token.symbol,
+        genericArgs[index] ?? token.default ?? token.constraints
+      );
+    });
+  }
+
+  // Fill in generics
+  const filledInNode = fillInGenerics(typeToFill, genericMap);
+  if (genericReference.property && filledInNode.type === 'object') {
+    return (
+      filledInNode.properties[genericReference.property].node ??
+      filledInNode.additionalProperties ?? { type: 'undefined' }
+    );
+  }
+
+  return filledInNode;
+}
+
+/**
+ * Combines two ObjectType objects to get a representation of the effective TypeScript interface of `base` extending `operand`
+ - * @param base The base interface
+ - * @param operand The interface that is extended
+ - * @param errorOnOverlap whether or not conflicting properties should throw an error or use the property from operand
+ - * @returns `ObjectType`
+ */
+export function computeEffectiveObject(
+  base: ObjectType,
+  operand: ObjectType,
+  errorOnOverlap = true
+): ObjectType {
+  const baseObjectName = base.name ?? 'object literal';
+  const operandObjectName = operand.name ?? 'object literal';
+  const newObject = {
+    ...base,
+    name: `${baseObjectName} & ${operandObjectName}`,
+    description: `Effective type combining ${baseObjectName} and ${operandObjectName}`,
+  };
+
+  // eslint-disable-next-line no-restricted-syntax, guard-for-in
+  for (const property in operand.properties) {
+    if (
+      newObject.properties[property] !== undefined &&
+      newObject.properties[property].node.type !==
+        operand.properties[property].node.type &&
+      errorOnOverlap
+    ) {
+      throw new Error(
+        `Can't compute effective type for ${baseObjectName} and ${operandObjectName} because of conflicting properties ${property}`
+      );
+    }
+
+    newObject.properties[property] = operand.properties[property];
+  }
+
+  if (newObject.additionalProperties && operand.additionalProperties) {
+    newObject.additionalProperties = {
+      type: 'and',
+      and: [newObject.additionalProperties, operand.additionalProperties],
+    };
+  } else if (operand.additionalProperties) {
+    newObject.additionalProperties = operand.additionalProperties;
+  }
+
+  return newObject;
 }


### PR DESCRIPTION
 ## Release Notes

- Fixes `extends` not cascading through heritage classes
- Allows you to specify if you want the SDK to return the raw type or `extends` and other generics filled in
- Allows you to validate by type registered in SDK or by a specific XLR. 
- Fixes Language Service validating Flow nodes with `validation` property on `View` type instead of generic value
- Changed interface for importing from a module to take the raw `TSManifest` and `manifest.js` uses `require` instead of `import`
- Fixed CLI not parsing flags correctly
- Add support for using `typeof` and an array constant to enumerate a type literal union
- Fixes XLR -> TS export when a heritage class includes a reference parameter
- Fix getting name for plugin during compile
- Fix TemplateNode being considered a PrimitiveType
- Fix xlr template to ts conversion
- Fix issue with walker recursion
- Fix Runtime conditionals in validation
- Fix issue with modifying nodes returned from cache causing changes across the tree
- Use effective XLRs in export
- Delete generic tokens when filled in
- Fix generic tokens not cascading when getting effective object

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.1--canary.16.331</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.2.1--canary.16.331
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
