### PR TITLE
Pin typescript version in cli now that we're using new features.

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -31,6 +31,7 @@ BUILD_DATA = [
     "@npm//mkdirp",
     "@npm//vscode-languageserver-textdocument",
     "@npm//vscode-languageserver-types",
+    "@npm//typescript",
     "//language/dsl:@player-tools/dsl",
     "//language/service:@player-tools/language-service",
     "//xlr/sdk:@player-tools/xlr-sdk",


### PR DESCRIPTION

## Release Notes
Fixes errors in projects using typescript < 4.8
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.2--canary.19.409</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.2.2--canary.19.409
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
