### PR TITLE
forward parameters to synthetic node for arrow functions with parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,8 @@ jobs:
       - attach_workspace:
           at: ~/tools
 
+      - run: yarn
+
       - run: bazel test --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY} --config=ci -- //...
 
       - run:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = (env, argv) => ({
       },
       {
         test: /\.m?js$/,
+        type: 'javascript/auto',
         use: {
           loader: 'babel-loader',
           options: {

--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -826,50 +826,6 @@ Array [
 ]
 `;
 
-exports[`Variable Exports Aliased function 1`] = `
-Array [
-  Object {
-    "name": "foo",
-    "parameters": Array [
-      Object {
-        "default": undefined,
-        "name": "input",
-        "optional": undefined,
-        "type": Object {
-          "type": "number",
-        },
-      },
-    ],
-    "returnType": Object {
-      "additionalProperties": false,
-      "genericTokens": undefined,
-      "name": "Bar",
-      "properties": Object {
-        "foo": Object {
-          "node": Object {
-            "title": "Bar.foo",
-            "type": "string",
-          },
-          "required": true,
-        },
-        "fuz": Object {
-          "node": Object {
-            "title": "Bar.fuz",
-            "type": "number",
-          },
-          "required": true,
-        },
-      },
-      "source": "filename.ts",
-      "title": "Bar",
-      "type": "object",
-    },
-    "source": "filename.ts",
-    "type": "function",
-  },
-]
-`;
-
 exports[`Variable Exports Aliased variable 1`] = `
 Array [
   Object {
@@ -962,6 +918,50 @@ Array [
   Object {
     "name": "foo",
     "parameters": Array [],
+    "returnType": Object {
+      "additionalProperties": false,
+      "genericTokens": undefined,
+      "name": "Bar",
+      "properties": Object {
+        "foo": Object {
+          "node": Object {
+            "title": "Bar.foo",
+            "type": "string",
+          },
+          "required": true,
+        },
+        "fuz": Object {
+          "node": Object {
+            "title": "Bar.fuz",
+            "type": "number",
+          },
+          "required": true,
+        },
+      },
+      "source": "filename.ts",
+      "title": "Bar",
+      "type": "object",
+    },
+    "source": "filename.ts",
+    "type": "function",
+  },
+]
+`;
+
+exports[`Variable Exports Arrow function with parameters 1`] = `
+Array [
+  Object {
+    "name": "foo",
+    "parameters": Array [
+      Object {
+        "default": undefined,
+        "name": "input",
+        "optional": undefined,
+        "type": Object {
+          "type": "number",
+        },
+      },
+    ],
     "returnType": Object {
       "additionalProperties": false,
       "genericTokens": undefined,

--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -826,6 +826,50 @@ Array [
 ]
 `;
 
+exports[`Variable Exports Aliased function 1`] = `
+Array [
+  Object {
+    "name": "foo",
+    "parameters": Array [
+      Object {
+        "default": undefined,
+        "name": "input",
+        "optional": undefined,
+        "type": Object {
+          "type": "number",
+        },
+      },
+    ],
+    "returnType": Object {
+      "additionalProperties": false,
+      "genericTokens": undefined,
+      "name": "Bar",
+      "properties": Object {
+        "foo": Object {
+          "node": Object {
+            "title": "Bar.foo",
+            "type": "string",
+          },
+          "required": true,
+        },
+        "fuz": Object {
+          "node": Object {
+            "title": "Bar.fuz",
+            "type": "number",
+          },
+          "required": true,
+        },
+      },
+      "source": "filename.ts",
+      "title": "Bar",
+      "type": "object",
+    },
+    "source": "filename.ts",
+    "type": "function",
+  },
+]
+`;
+
 exports[`Variable Exports Aliased variable 1`] = `
 Array [
   Object {

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -634,4 +634,26 @@ describe('Variable Exports', () => {
 
     expect(XLR).toMatchSnapshot();
   });
+
+  it('Aliased function', () => {
+    const sc = `
+      interface Bar {
+        foo: string
+        fuz: number
+      }
+
+      export const foo = (input: number): Bar => {
+        return {
+          foo: '1',
+          fuz: 1,
+        };
+      };
+    `;
+
+    const { sf, tc } = setupTestEnv(sc);
+    const converter = new TsConverter(tc);
+    const XLR = converter.convertSourceFile(sf).data.types;
+
+    expect(XLR).toMatchSnapshot();
+  });
 });

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -635,7 +635,7 @@ describe('Variable Exports', () => {
     expect(XLR).toMatchSnapshot();
   });
 
-  it('Aliased function', () => {
+  it('Arrow function with parameters', () => {
     const sc = `
       interface Bar {
         foo: string

--- a/xlr/converters/src/ts-to-xlr.ts
+++ b/xlr/converters/src/ts-to-xlr.ts
@@ -629,11 +629,21 @@ export class TsConverter {
     const functionReturnType =
       this.context.typeChecker.getTypeAtLocation(functionCall);
 
-    const syntheticNode = this.context.typeChecker.typeToTypeNode(
+    let syntheticNode = this.context.typeChecker.typeToTypeNode(
       functionReturnType,
       document,
       undefined
     );
+
+    // Synthetic node loses parameter location information, and text making it unable
+    // to get the parameter name in tsNodeToType
+    if (ts.isArrowFunction(functionCall)) {
+      const syntheticWithParameters = {
+        ...syntheticNode,
+        parameters: functionCall.parameters,
+      };
+      syntheticNode = syntheticWithParameters as unknown as ts.TypeNode;
+    }
 
     if (syntheticNode) {
       if (


### PR DESCRIPTION
while trying to understand things for  #21 

i found that top level exported arrow functions with parameters crashed in a test, params in the synthetic `ts.TypeNode` have `-1` position information, and pretty much every other property is `undefined` including `text`, so `param.name.getText()` was crashing

i copied params onto the synthetic node from the original node