### PR TITLE
fix function aliasing exporting wrong name

### DIFF
--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -826,7 +826,7 @@ Array [
 ]
 `;
 
-exports[`Variable Exports Aliased Arrow function with parameters 1`] = `
+exports[`Variable Exports Aliased Arrow function exports its own name 1`] = `
 Array [
   Object {
     "name": "foo",

--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -826,6 +826,89 @@ Array [
 ]
 `;
 
+exports[`Variable Exports Aliased Arrow function with parameters 1`] = `
+Array [
+  Object {
+    "name": "foo",
+    "parameters": Array [
+      Object {
+        "default": undefined,
+        "name": "input",
+        "optional": undefined,
+        "type": Object {
+          "type": "number",
+        },
+      },
+    ],
+    "returnType": Object {
+      "additionalProperties": false,
+      "genericTokens": undefined,
+      "name": "Bar",
+      "properties": Object {
+        "foo": Object {
+          "node": Object {
+            "title": "Bar.foo",
+            "type": "string",
+          },
+          "required": true,
+        },
+        "fuz": Object {
+          "node": Object {
+            "title": "Bar.fuz",
+            "type": "number",
+          },
+          "required": true,
+        },
+      },
+      "source": "filename.ts",
+      "title": "Bar",
+      "type": "object",
+    },
+    "source": "filename.ts",
+    "type": "function",
+  },
+  Object {
+    "name": "baz",
+    "parameters": Array [
+      Object {
+        "default": undefined,
+        "name": "input",
+        "optional": undefined,
+        "type": Object {
+          "type": "number",
+        },
+      },
+    ],
+    "returnType": Object {
+      "additionalProperties": false,
+      "genericTokens": undefined,
+      "name": "Bar",
+      "properties": Object {
+        "foo": Object {
+          "node": Object {
+            "title": "Bar.foo",
+            "type": "string",
+          },
+          "required": true,
+        },
+        "fuz": Object {
+          "node": Object {
+            "title": "Bar.fuz",
+            "type": "number",
+          },
+          "required": true,
+        },
+      },
+      "source": "filename.ts",
+      "title": "Bar",
+      "type": "object",
+    },
+    "source": "filename.ts",
+    "type": "function",
+  },
+]
+`;
+
 exports[`Variable Exports Aliased variable 1`] = `
 Array [
   Object {

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -656,4 +656,28 @@ describe('Variable Exports', () => {
 
     expect(XLR).toMatchSnapshot();
   });
+
+  it('Aliased Arrow function exports its own name', () => {
+    const sc = `
+      interface Bar {
+        foo: string
+        fuz: number
+      }
+
+      export const foo = (input: number): Bar => {
+        return {
+          foo: '1',
+          fuz: 1,
+        };
+      };
+
+      export const baz = foo
+    `;
+
+    const { sf, tc } = setupTestEnv(sc);
+    const converter = new TsConverter(tc);
+    const XLR = converter.convertSourceFile(sf).data.types;
+
+    expect(XLR).toMatchSnapshot();
+  });
 });

--- a/xlr/converters/src/ts-to-xlr.ts
+++ b/xlr/converters/src/ts-to-xlr.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import type {
+import {
   NodeType,
   FunctionTypeParameters,
   TupleType,
@@ -179,16 +179,6 @@ export class TsConverter {
       const variable = variableDeclarations[0];
 
       if (variable.initializer) {
-        const type = this.context.typeChecker.getTypeAtLocation(
-          variable.initializer
-        );
-
-        const typeNode = this.context.typeChecker.typeToTypeNode(
-          type,
-          variable.initializer,
-          ts.NodeBuilderFlags.None
-        );
-
         let resultingNode;
         if (
           ts.isCallExpression(variable.initializer) ||
@@ -202,10 +192,10 @@ export class TsConverter {
           resultingNode = this.tsLiteralToType(variable.initializer);
         }
 
-        // If initializer type is a reference to a function and not a concrete value
+        // If resultingNode is a reference to a function and not a concrete value
         // we need to update the name to be the name of the exporting variable
         // not the name of the identifier its aliasing
-        if (ts.isFunctionLike(typeNode)) {
+        if (resultingNode.type === 'function') {
           resultingNode = { ...resultingNode, name: variable.name.getText() };
         }
 

--- a/xlr/converters/src/ts-to-xlr.ts
+++ b/xlr/converters/src/ts-to-xlr.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import {
+import type {
   NodeType,
   FunctionTypeParameters,
   TupleType,


### PR DESCRIPTION
checks the effective type of the initializer statement to see if its a function, rather than a concrete type

if it is a function, we update the name to be the name of the exporting variable, not the name of the identifier it is aliasing

resolves #21 