### PR TITLE
feat: added ability to add player plugins that don't have a manifest in dnd library

### DIFF
--- a/drag-and-drop/app/pages/index.tsx
+++ b/drag-and-drop/app/pages/index.tsx
@@ -573,12 +573,8 @@ const App = () => {
     const config: DragAndDropControllerOptions = {
       Component: AssetDropTarget,
       playerTypes: typesManifest as TSManifest,
-      extensions: [
-        {
-          plugin: ReferenceAssetsPlugin,
-          manifest: pluginManifest as TSManifest,
-        },
-      ],
+      extensionTypes: [pluginManifest as TSManifest],
+      extensions: [ReferenceAssetsPlugin],
       async resolveRequiredProperties(
         asset: Asset<string>,
         type: ObjectType

--- a/drag-and-drop/app/pages/index.tsx
+++ b/drag-and-drop/app/pages/index.tsx
@@ -573,8 +573,8 @@ const App = () => {
     const config: DragAndDropControllerOptions = {
       Component: AssetDropTarget,
       playerTypes: typesManifest as TSManifest,
-      extensionTypes: [pluginManifest as TSManifest],
-      extensions: [ReferenceAssetsPlugin],
+      manifests: [pluginManifest as TSManifest],
+      plugins: [ReferenceAssetsPlugin],
       async resolveRequiredProperties(
         asset: Asset<string>,
         type: ObjectType

--- a/drag-and-drop/library/src/__tests__/controller.test.tsx
+++ b/drag-and-drop/library/src/__tests__/controller.test.tsx
@@ -4,11 +4,7 @@ import pluginManifest from '@player-tools/static-xlrs/static_xlrs/plugin/xlr/man
 import typesManifest from '@player-tools/static-xlrs/static_xlrs/core/xlr/manifest';
 import type { ObjectType } from '@player-tools/xlr';
 import { DragAndDropController } from '../controller';
-import type {
-  DropTargetAsset,
-  DropTargetAssetContext,
-  ExtensionProvider,
-} from '../types';
+import type { DropTargetAsset, DropTargetAssetContext } from '../types';
 import { getAssetSymbol } from '../utils/helpers';
 
 const referenceAssetExtension = {
@@ -23,8 +19,8 @@ describe('drag-and-drop', () => {
     const mockHandleStateChange = jest.fn();
     const dndController = new DragAndDropController({
       playerTypes: typesManifest,
-      extensionTypes: [referenceAssetExtension.manifest],
-      extensions: [referenceAssetExtension.plugin],
+      manifests: [referenceAssetExtension.manifest],
+      plugins: [referenceAssetExtension.plugin],
       resolveRequiredProperties: async (
         asset: Asset<string>,
         type: ObjectType
@@ -203,8 +199,8 @@ describe('drag-and-drop', () => {
     };
     const dndController = new DragAndDropController({
       playerTypes: typesManifest,
-      extensionTypes: [referenceAssetExtension.manifest],
-      extensions: [referenceAssetExtension.plugin],
+      manifests: [referenceAssetExtension.manifest],
+      plugins: [referenceAssetExtension.plugin],
       resolveRequiredProperties: jest.fn(),
       resolveCollectionConversion: jest.fn(),
       handleDndStateChange: jest.fn(),
@@ -271,8 +267,8 @@ describe('drag-and-drop', () => {
     };
     const dndController = new DragAndDropController({
       playerTypes: typesManifest,
-      extensionTypes: [referenceAssetExtension.manifest],
-      extensions: [referenceAssetExtension.plugin],
+      manifests: [referenceAssetExtension.manifest],
+      plugins: [referenceAssetExtension.plugin],
       resolveRequiredProperties: jest.fn(),
       resolveCollectionConversion: jest.fn(),
       handleDndStateChange: jest.fn(),

--- a/drag-and-drop/library/src/__tests__/controller.test.tsx
+++ b/drag-and-drop/library/src/__tests__/controller.test.tsx
@@ -11,7 +11,7 @@ import type {
 } from '../types';
 import { getAssetSymbol } from '../utils/helpers';
 
-const referenceAssetExtension: ExtensionProvider = {
+const referenceAssetExtension = {
   plugin: class test {
     name = 'test';
   },
@@ -23,7 +23,8 @@ describe('drag-and-drop', () => {
     const mockHandleStateChange = jest.fn();
     const dndController = new DragAndDropController({
       playerTypes: typesManifest,
-      extensions: [referenceAssetExtension],
+      extensionTypes: [referenceAssetExtension.manifest],
+      extensions: [referenceAssetExtension.plugin],
       resolveRequiredProperties: async (
         asset: Asset<string>,
         type: ObjectType
@@ -202,7 +203,8 @@ describe('drag-and-drop', () => {
     };
     const dndController = new DragAndDropController({
       playerTypes: typesManifest,
-      extensions: [referenceAssetExtension],
+      extensionTypes: [referenceAssetExtension.manifest],
+      extensions: [referenceAssetExtension.plugin],
       resolveRequiredProperties: jest.fn(),
       resolveCollectionConversion: jest.fn(),
       handleDndStateChange: jest.fn(),
@@ -269,7 +271,8 @@ describe('drag-and-drop', () => {
     };
     const dndController = new DragAndDropController({
       playerTypes: typesManifest,
-      extensions: [referenceAssetExtension],
+      extensionTypes: [referenceAssetExtension.manifest],
+      extensions: [referenceAssetExtension.plugin],
       resolveRequiredProperties: jest.fn(),
       resolveCollectionConversion: jest.fn(),
       handleDndStateChange: jest.fn(),

--- a/drag-and-drop/library/src/controller.tsx
+++ b/drag-and-drop/library/src/controller.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import type { Asset, AssetWrapper, ReactPlayer, View } from '@player-ui/react';
+import type {
+  Asset,
+  AssetWrapper,
+  ReactPlayer,
+  View,
+  ReactPlayerPlugin,
+} from '@player-ui/react';
 import { ConsoleLogger, WebPlayer } from '@player-ui/react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -19,6 +25,8 @@ import { removeDndStateFromView } from './utils/helpers';
 export interface DragAndDropControllerOptions {
   /** The list of XLR enabled extensions to load as available resources */
   extensions?: Array<ExtensionProvider>;
+  /** Player plugins that aren't necessarily assets to be dragged and dropped. */
+  plugins?: Array<ReactPlayerPlugin>;
 
   /** Manifest for the base Player types package  to use */
   playerTypes: TSManifest;
@@ -129,6 +137,7 @@ export class DragAndDropController {
         this.dndWebPlayerPlugin,
         // eslint-disable-next-line new-cap
         ...(options?.extensions ?? []).map((e) => new e.plugin()),
+        ...(options?.plugins ?? []),
       ],
     });
 

--- a/drag-and-drop/library/src/controller.tsx
+++ b/drag-and-drop/library/src/controller.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import type {
-  Asset,
-  AssetWrapper,
-  ReactPlayer,
-  View,
-  ReactPlayerPlugin,
-} from '@player-ui/react';
+import type { Asset, AssetWrapper, ReactPlayer, View } from '@player-ui/react';
 import { ConsoleLogger, WebPlayer } from '@player-ui/react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -14,8 +8,8 @@ import { XLRService } from '@player-tools/language-service';
 import type { TypeMetadata } from '@player-tools/xlr-sdk';
 import { PlayerDndPlugin } from './utils';
 import type {
-  ExtensionProvider,
   ExtensionProviderAssetIdentifier,
+  PluginProvider,
   TransformedDropTargetAssetType,
 } from './types';
 import { RuntimeFlowState } from './utils/runtime-flow-state';
@@ -23,13 +17,11 @@ import { DropComponent } from './utils/drop-component';
 import { removeDndStateFromView } from './utils/helpers';
 
 export interface DragAndDropControllerOptions {
-  /** The list of extensions to load as available resources or extend Player */
-  extensions?: Array<ExtensionProvider>;
-  /** Player plugins that aren't necessarily assets to be dragged and dropped. */
-  plugins?: Array<ReactPlayerPlugin>;
+  /** Player plugins for adding assets and functionality */
+  plugins?: Array<PluginProvider>;
 
   /** Manifest for extensions that have drag and drop assets */
-  extensionTypes?: Array<TSManifest>;
+  manifests?: Array<TSManifest>;
 
   /** Manifest for the base Player types package  to use */
   playerTypes: TSManifest;
@@ -93,7 +85,7 @@ export class DragAndDropController {
 
     this.PlayerXLRService = new XLRService();
     this.PlayerXLRService.XLRSDK.loadDefinitionsFromModule(options.playerTypes);
-    options?.extensionTypes?.forEach((manifest) => {
+    options?.manifests?.forEach((manifest) => {
       this.PlayerXLRService.XLRSDK.loadDefinitionsFromModule(manifest);
     });
 
@@ -137,7 +129,7 @@ export class DragAndDropController {
       plugins: [
         this.dndWebPlayerPlugin,
         // eslint-disable-next-line new-cap
-        ...(options?.extensions ?? []).map((e) => new e()),
+        ...(options?.plugins ?? []).map((e) => new e()),
       ],
     });
 

--- a/drag-and-drop/library/src/controller.tsx
+++ b/drag-and-drop/library/src/controller.tsx
@@ -23,10 +23,13 @@ import { DropComponent } from './utils/drop-component';
 import { removeDndStateFromView } from './utils/helpers';
 
 export interface DragAndDropControllerOptions {
-  /** The list of XLR enabled extensions to load as available resources */
+  /** The list of extensions to load as available resources or extend Player */
   extensions?: Array<ExtensionProvider>;
   /** Player plugins that aren't necessarily assets to be dragged and dropped. */
   plugins?: Array<ReactPlayerPlugin>;
+
+  /** Manifest for extensions that have drag and drop assets */
+  extensionTypes?: Array<TSManifest>;
 
   /** Manifest for the base Player types package  to use */
   playerTypes: TSManifest;
@@ -90,10 +93,8 @@ export class DragAndDropController {
 
     this.PlayerXLRService = new XLRService();
     this.PlayerXLRService.XLRSDK.loadDefinitionsFromModule(options.playerTypes);
-    options?.extensions?.forEach((extension) => {
-      this.PlayerXLRService.XLRSDK.loadDefinitionsFromModule(
-        extension.manifest
-      );
+    options?.extensionTypes?.forEach((manifest) => {
+      this.PlayerXLRService.XLRSDK.loadDefinitionsFromModule(manifest);
     });
 
     this.runtimeState = new RuntimeFlowState({
@@ -136,8 +137,7 @@ export class DragAndDropController {
       plugins: [
         this.dndWebPlayerPlugin,
         // eslint-disable-next-line new-cap
-        ...(options?.extensions ?? []).map((e) => new e.plugin()),
-        ...(options?.plugins ?? []),
+        ...(options?.extensions ?? []).map((e) => new e()),
       ],
     });
 

--- a/drag-and-drop/library/src/types.ts
+++ b/drag-and-drop/library/src/types.ts
@@ -15,12 +15,7 @@ export type FlowWithOneView<T extends Asset = Asset> = Flow<T> & {
 
 export interface ExtensionProvider {
   /** A constructor to create an instance of the plugin */
-  plugin: {
-    new (): ReactPlayerPlugin;
-  };
-
-  /** A manifest describing the plugins capabilities */
-  manifest: TSManifest;
+  new (): ReactPlayerPlugin;
 }
 
 export interface ExtensionProviderAssetIdentifier {

--- a/drag-and-drop/library/src/types.ts
+++ b/drag-and-drop/library/src/types.ts
@@ -13,7 +13,7 @@ export type FlowWithOneView<T extends Asset = Asset> = Flow<T> & {
   views: [View<T>];
 };
 
-export interface ExtensionProvider {
+export interface PluginProvider {
   /** A constructor to create an instance of the plugin */
   new (): ReactPlayerPlugin;
 }


### PR DESCRIPTION
## Context 
Currently any player plugin added needs a manifest as well.  This should only be for assets that need to be dragged and dropped.

## What Changed
- updated the config that is passed into the DragAndDropController so the manifest is passed in separately.
- verified tests are still green.