### PR TITLE
add missing resolve in cli

### DIFF
--- a/cli/src/utils/babel-register.ts
+++ b/cli/src/utils/babel-register.ts
@@ -10,6 +10,6 @@ export const registerForPaths = () => {
       require.resolve('@babel/preset-typescript'),
       require.resolve('@babel/preset-react'),
     ],
-    plugins: ['@babel/plugin-transform-react-jsx-source'],
+    plugins: [require.resolve('@babel/plugin-transform-react-jsx-source')],
   });
 };


### PR DESCRIPTION
## Release Notes
Add missing `require.resolve` on resolution of `@babel/plugin-transform-react-jsx-source` in cli causing issues when compiling content

### Change Type (required)
- [x] `patch`
- [ ] `minor`
- [ ] `major`