### PR TITLE
Validation Improvements

### DIFF
--- a/cli/src/commands/json/validate.ts
+++ b/cli/src/commands/json/validate.ts
@@ -60,6 +60,7 @@ export default class Validate extends BaseCommand {
     const results = {
       exitCode: 0,
     };
+    const lsp = await this.createLanguageService(exp);
 
     const taskRunner = createTaskRunner({
       renderer: validationRenderer,
@@ -69,7 +70,6 @@ export default class Validate extends BaseCommand {
         },
         run: async () => {
           const contents = await fs.readFile(f, 'utf-8');
-          const lsp = await this.createLanguageService(exp);
 
           const validations =
             (await lsp.validateTextDocument(

--- a/cli/src/plugins/LSPAssetsPlugin.ts
+++ b/cli/src/plugins/LSPAssetsPlugin.ts
@@ -32,8 +32,6 @@ export class LSPAssetsPlugin implements PlayerCLIPlugin {
   }
 
   async onCreateLanguageService(lsp: PlayerLanguageService, exp: boolean) {
-    if (exp === this.config.exp) {
-      await lsp.setAssetTypes([this.config.path]);
-    }
+    await lsp.setAssetTypes([this.config.path]);
   }
 }

--- a/language/json-language-service/src/plugins/__tests__/nav-state-plugin.test.ts
+++ b/language/json-language-service/src/plugins/__tests__/nav-state-plugin.test.ts
@@ -95,6 +95,37 @@ describe('nav-state-plugin', () => {
     );
     const diags = await service.validateTextDocument(testDocument);
 
-    expect(diags?.filter((d) => d.severity !== 2)).toHaveLength(0);
+    expect(diags?.filter((d) => d.severity !== 2)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "message": "Warning - View Type view was not loaded into Validator definitions",
+          "range": Object {
+            "end": Object {
+              "character": 5,
+              "line": 6,
+            },
+            "start": Object {
+              "character": 4,
+              "line": 3,
+            },
+          },
+          "severity": 1,
+        },
+        Object {
+          "message": "Warning - View Type view was not loaded into Validator definitions",
+          "range": Object {
+            "end": Object {
+              "character": 5,
+              "line": 10,
+            },
+            "start": Object {
+              "character": 4,
+              "line": 7,
+            },
+          },
+          "severity": 1,
+        },
+      ]
+    `);
   });
 });

--- a/language/json-language-service/src/plugins/xlr-plugin.ts
+++ b/language/json-language-service/src/plugins/xlr-plugin.ts
@@ -1,4 +1,4 @@
-import type { NodeType, ObjectType } from '@player-tools/xlr';
+import type { NodeType } from '@player-tools/xlr';
 import type { XLRSDK } from '@player-tools/xlr-sdk';
 import type { CompletionItem } from 'vscode-languageserver-types';
 import {

--- a/language/json-language-service/src/plugins/xlr-plugin.ts
+++ b/language/json-language-service/src/plugins/xlr-plugin.ts
@@ -55,7 +55,7 @@ function createValidationVisitor(
         ctx.addViolation({
           node: assetNode,
           message: `Warning - Asset Type ${assetNode.assetType?.valueNode?.value} was not loaded into Validator definitions`,
-          severity: DiagnosticSeverity.Warning,
+          severity: DiagnosticSeverity.Error,
         });
         expectedType = 'Asset';
       }
@@ -82,7 +82,7 @@ function createValidationVisitor(
         ctx.addViolation({
           node: viewNode,
           message: `Warning - View Type ${viewNode.viewType?.valueNode?.value} was not loaded into Validator definitions`,
-          severity: DiagnosticSeverity.Warning,
+          severity: DiagnosticSeverity.Error,
         });
         expectedType = 'View';
       }

--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -1,5 +1,115 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Complex Types Exclude with objects 1`] = `
+Array [
+  Object {
+    "genericTokens": undefined,
+    "name": "foo",
+    "or": Array [
+      Object {
+        "additionalProperties": false,
+        "properties": Object {
+          "type": Object {
+            "node": Object {
+              "const": "b",
+              "title": "foo.type",
+              "type": "string",
+            },
+            "required": true,
+          },
+          "value": Object {
+            "node": Object {
+              "title": "foo.value",
+              "type": "number",
+            },
+            "required": true,
+          },
+        },
+        "title": "foo",
+        "type": "object",
+      },
+      Object {
+        "additionalProperties": false,
+        "properties": Object {
+          "type": Object {
+            "node": Object {
+              "const": "c",
+              "title": "foo.type",
+              "type": "string",
+            },
+            "required": true,
+          },
+          "value": Object {
+            "node": Object {
+              "title": "foo.value",
+              "type": "boolean",
+            },
+            "required": true,
+          },
+        },
+        "title": "foo",
+        "type": "object",
+      },
+    ],
+    "source": "filename.ts",
+    "title": "bar",
+    "type": "or",
+  },
+]
+`;
+
+exports[`Complex Types Exclude with objects collapses single remaining element 1`] = `
+Array [
+  Object {
+    "additionalProperties": false,
+    "genericTokens": undefined,
+    "name": "bar",
+    "properties": Object {
+      "type": Object {
+        "node": Object {
+          "const": "b",
+          "title": "foo.type",
+          "type": "string",
+        },
+        "required": true,
+      },
+      "value": Object {
+        "node": Object {
+          "title": "foo.value",
+          "type": "number",
+        },
+        "required": true,
+      },
+    },
+    "source": "filename.ts",
+    "title": "bar",
+    "type": "object",
+  },
+]
+`;
+
+exports[`Complex Types Exclude with primitives 1`] = `
+Array [
+  Object {
+    "genericTokens": undefined,
+    "name": "fooType",
+    "or": Array [
+      Object {
+        "const": "b",
+        "type": "string",
+      },
+      Object {
+        "const": "c",
+        "type": "string",
+      },
+    ],
+    "source": "filename.ts",
+    "title": "bar",
+    "type": "or",
+  },
+]
+`;
+
 exports[`Complex Types Omit 1`] = `
 Array [
   Object {

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -343,6 +343,50 @@ describe('Complex Types', () => {
 
     expect(XLR).toMatchSnapshot();
   });
+
+  it('Exclude with primitives', () => {
+    const sc = `
+    const foo = ['a', 'b', 'c'] as const;
+
+    type fooType = typeof foo[number];
+    
+    export type bar = Exclude<fooType, 'a'>;
+    `;
+
+    const { sf, tc } = setupTestEnv(sc);
+    const converter = new TsConverter(tc);
+    const XLR = converter.convertSourceFile(sf).data.types;
+
+    expect(XLR).toMatchSnapshot();
+  });
+
+  it('Exclude with objects', () => {
+    const sc = `
+    type foo = { type: 'a'; value: string } | { type: 'b'; value: number } | { type: 'c'; value: boolean };
+
+    export type bar = Exclude<foo, { type: 'a' }>;
+    `;
+
+    const { sf, tc } = setupTestEnv(sc);
+    const converter = new TsConverter(tc);
+    const XLR = converter.convertSourceFile(sf).data.types;
+
+    expect(XLR).toMatchSnapshot();
+  });
+
+  it('Exclude with objects collapses single remaining element', () => {
+    const sc = `
+    type foo = { type: 'a'; value: string } | { type: 'b'; value: number };
+
+    export type bar = Exclude<foo, { type: 'a' }>;
+    `;
+
+    const { sf, tc } = setupTestEnv(sc);
+    const converter = new TsConverter(tc);
+    const XLR = converter.convertSourceFile(sf).data.types;
+
+    expect(XLR).toMatchSnapshot();
+  });
 });
 
 describe('String Templates', () => {

--- a/xlr/converters/src/ts-to-xlr.ts
+++ b/xlr/converters/src/ts-to-xlr.ts
@@ -13,6 +13,7 @@ import type {
   ConditionalType,
   RefType,
   ArrayType,
+  OrType,
 } from '@player-tools/xlr';
 import type {
   TopLevelDeclaration,
@@ -37,16 +38,17 @@ import {
   isTopLevelNode,
   isTopLevelDeclaration,
   resolveConditional,
+  applyExcludeToNodeType,
 } from '@player-tools/xlr-utils';
 import { ConversionError } from './types';
+
+export type MappedType = 'Pick' | 'Omit' | 'Required' | 'Partial' | 'Exclude';
 
 /**
  * Returns if the string is one of TypeScript's MappedTypes
  */
-export function isMappedTypeNode(
-  x: string
-): x is 'Pick' | 'Omit' | 'Required' | 'Partial' {
-  return ['Pick', 'Omit', 'Required', 'Partial'].includes(x);
+export function isMappedTypeNode(x: string): x is MappedType {
+  return ['Pick', 'Omit', 'Required', 'Partial', 'Exclude'].includes(x);
 }
 
 export interface TSConverterContext {
@@ -1024,21 +1026,33 @@ export class TsConverter {
   }
 
   private makeMappedType(
-    refName: 'Pick' | 'Omit' | 'Partial' | 'Required',
+    refName: MappedType,
     node: ts.NodeWithTypeArguments
   ): ObjectType {
-    if (refName === 'Pick' || refName === 'Omit') {
+    if (refName === 'Pick' || refName === 'Omit' || refName === 'Exclude') {
       const baseType = node.typeArguments?.[0] as ts.TypeNode;
       const modifiers = node.typeArguments?.[1] as ts.TypeNode;
 
-      const baseObj = this.convertTsTypeNode(baseType) as NamedType<ObjectType>;
-      const modifierNames = getStringLiteralsFromUnion(modifiers);
+      const baseObj = this.convertTsTypeNode(baseType);
 
-      return applyPickOrOmitToNodeType(
-        baseObj,
-        refName,
-        modifierNames
-      ) as ObjectType;
+      if (refName === 'Exclude') {
+        if (baseObj.type === 'or') {
+          return applyExcludeToNodeType(
+            baseObj as OrType,
+            this.convertTsTypeNode(modifiers)
+          );
+        }
+
+        throw new ConversionError(
+          "Error: Can't solve Exclude type on non-union node"
+        );
+      } else {
+        return applyPickOrOmitToNodeType(
+          baseObj,
+          refName,
+          getStringLiteralsFromUnion(modifiers)
+        ) as ObjectType;
+      }
     }
 
     if (refName === 'Partial' || refName === 'Required') {

--- a/xlr/converters/src/ts-to-xlr.ts
+++ b/xlr/converters/src/ts-to-xlr.ts
@@ -1040,7 +1040,7 @@ export class TsConverter {
           return applyExcludeToNodeType(
             baseObj as OrType,
             this.convertTsTypeNode(modifiers)
-          );
+          ) as ObjectType;
         }
 
         throw new ConversionError(

--- a/xlr/sdk/src/sdk.ts
+++ b/xlr/sdk/src/sdk.ts
@@ -166,11 +166,11 @@ export class XLRSDK {
       return this.computedNodeCache.get(id) as NamedType<NodeType> | undefined;
     }
 
-    type = this.resolveType(type);
+    type = fillInGenerics(this.resolveType(type)) as NamedType;
 
     this.computedNodeCache.set(id, type);
 
-    return fillInGenerics(type) as NamedType;
+    return type;
   }
 
   /**
@@ -297,7 +297,7 @@ export class XLRSDK {
       }
 
       return objectNode;
-    })(fillInGenerics(type), 'any') as NamedType;
+    })(type, 'any') as NamedType;
   }
 
   private exportToTypeScript(

--- a/xlr/sdk/src/validator.ts
+++ b/xlr/sdk/src/validator.ts
@@ -57,7 +57,10 @@ export class XLRValidator {
         });
       }
     } else if (xlrNode.type === 'template') {
-      this.validateTemplate(rootNode, xlrNode);
+      const error = this.validateTemplate(rootNode, xlrNode);
+      if (error) {
+        validationIssues.push(error);
+      }
     } else if (xlrNode.type === 'or') {
       // eslint-disable-next-line no-restricted-syntax
       for (const potentialType of xlrNode.or) {

--- a/xlr/sdk/src/validator.ts
+++ b/xlr/sdk/src/validator.ts
@@ -193,22 +193,15 @@ export class XLRValidator {
     const issues: Array<ValidationError> = [];
     const objectProps = makePropertyMap(node);
 
-    let effectiveXLRNode = xlrNode;
-
-    if (xlrNode.extends) {
-      const extendedNode = this.getRefType(xlrNode.extends) as ObjectType;
-      effectiveXLRNode = computeEffectiveObject(extendedNode, xlrNode);
-    }
-
     // eslint-disable-next-line guard-for-in, no-restricted-syntax
-    for (const prop in effectiveXLRNode.properties) {
-      const expectedType = effectiveXLRNode.properties[prop];
+    for (const prop in xlrNode.properties) {
+      const expectedType = xlrNode.properties[prop];
       const valueNode = objectProps.get(prop);
       if (expectedType.required && valueNode === undefined) {
         issues.push({
           type: 'missing',
           node,
-          message: `Property '${prop}' missing from type '${effectiveXLRNode.name}'`,
+          message: `Property '${prop}' missing from type '${xlrNode.name}'`,
         });
       }
 
@@ -221,25 +214,22 @@ export class XLRValidator {
 
     // Check if unknown keys are allowed and if they are - do the violate the constraint
     const extraKeys = Array.from(objectProps.keys()).filter(
-      (key) => effectiveXLRNode.properties[key] === undefined
+      (key) => xlrNode.properties[key] === undefined
     );
-    if (
-      effectiveXLRNode.additionalProperties === false &&
-      extraKeys.length > 0
-    ) {
+    if (xlrNode.additionalProperties === false && extraKeys.length > 0) {
       issues.push({
         type: 'value',
         node,
-        message: `Unexpected properties on '${
-          effectiveXLRNode.name
-        }': ${extraKeys.join(', ')}`,
+        message: `Unexpected properties on '${xlrNode.name}': ${extraKeys.join(
+          ', '
+        )}`,
       });
     } else {
       issues.push(
         ...extraKeys.flatMap((key) =>
           this.validateType(
             objectProps.get(key) as Node,
-            effectiveXLRNode.additionalProperties as NodeType
+            xlrNode.additionalProperties as NodeType
           )
         )
       );

--- a/xlr/utils/src/__tests__/__snapshots__/validation-helpers.test.ts.snap
+++ b/xlr/utils/src/__tests__/__snapshots__/validation-helpers.test.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`computeEffectiveObject tests Merges equal additionalProperties 1`] = `
+Object {
+  "additionalProperties": Object {
+    "type": "unknown",
+  },
+  "description": "Effective type combining object literal and object literal",
+  "genericTokens": Array [],
+  "name": "object literal & object literal",
+  "properties": Object {
+    "bar": Object {
+      "node": Object {
+        "type": "number",
+      },
+      "required": true,
+    },
+    "foo": Object {
+      "node": Object {
+        "type": "string",
+      },
+      "required": true,
+    },
+  },
+  "type": "object",
+}
+`;
+
 exports[`computeEffectiveObject tests mixed test 1`] = `
 Object {
   "additionalProperties": Object {

--- a/xlr/utils/src/__tests__/validation-helpers.test.ts
+++ b/xlr/utils/src/__tests__/validation-helpers.test.ts
@@ -69,4 +69,38 @@ describe('computeEffectiveObject tests', () => {
       `"Can't compute effective type for object literal and object literal because of conflicting properties foo"`
     );
   });
+
+  it('Merges equal additionalProperties', () => {
+    const type1: ObjectType = {
+      type: 'object',
+      properties: {
+        foo: {
+          required: true,
+          node: {
+            type: 'string',
+          },
+        },
+      },
+      additionalProperties: {
+        type: 'unknown',
+      },
+    };
+
+    const type2: ObjectType = {
+      type: 'object',
+      properties: {
+        bar: {
+          required: true,
+          node: {
+            type: 'number',
+          },
+        },
+      },
+      additionalProperties: {
+        type: 'unknown',
+      },
+    };
+
+    expect(computeEffectiveObject(type1, type2)).toMatchSnapshot();
+  });
 });

--- a/xlr/utils/src/validation-helpers.ts
+++ b/xlr/utils/src/validation-helpers.ts
@@ -190,8 +190,8 @@ export function computeEffectiveObject(
   operand: ObjectType,
   errorOnOverlap = true
 ): ObjectType {
-  const baseObjectName = base.name ?? 'object literal';
-  const operandObjectName = operand.name ?? 'object literal';
+  const baseObjectName = base.name ?? base.title ?? 'object literal';
+  const operandObjectName = operand.name ?? operand.title ?? 'object literal';
   const newObject = {
     ...base,
     name: `${baseObjectName} & ${operandObjectName}`,

--- a/xlr/utils/src/validation-helpers.ts
+++ b/xlr/utils/src/validation-helpers.ts
@@ -1,3 +1,5 @@
+/* eslint-disable guard-for-in */
+/* eslint-disable no-restricted-syntax */
 import type { Node } from 'jsonc-parser';
 import type {
   ConditionalType,
@@ -55,34 +57,61 @@ export function isNode(obj: Node | string | number | boolean): obj is Node {
 }
 
 /**
+ * Computes if the first arg extends the second arg
+ */
+export function computeExtends(a: NodeType, b: NodeType): boolean {
+  // special case for any/unknown being functionally the same
+  if (
+    (a.type === 'any' || a.type === 'unknown') &&
+    (b.type === 'any' || b.type === 'unknown')
+  ) {
+    return true;
+  }
+
+  // special case for null/undefined being functionally the same
+  if (
+    (a.type === 'null' || a.type === 'undefined') &&
+    (b.type === 'null' || b.type === 'undefined')
+  ) {
+    return true;
+  }
+
+  if (a.type === b.type) {
+    if (isPrimitiveTypeNode(a) && isPrimitiveTypeNode(b)) {
+      if (a.const && b.const) {
+        if (a.const === b.const) {
+          return true;
+        }
+      } else {
+        return true;
+      }
+    }
+
+    if (a.type === 'object' && b.type === 'object') {
+      for (const property in b.properties) {
+        const propertyNode = b.properties[property];
+        if (
+          !a.properties[property] ||
+          !computeExtends(a.properties[property].node, propertyNode.node)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Attempts to resolve a conditional type
  */
 export function resolveConditional(conditional: ConditionalType): NodeType {
   const { left, right } = conditional.check;
   if (isPrimitiveTypeNode(left) && isPrimitiveTypeNode(right)) {
-    let conditionalResult = conditional.value.false;
-
-    if (
-      (left.type === 'any' || left.type === 'unknown') &&
-      (right.type === 'any' || right.type === 'unknown')
-    ) {
-      // special case for any/unknown being functionally the same
-      conditionalResult = conditional.value.true;
-    } else if (
-      (left.type === 'null' || left.type === 'undefined') &&
-      (right.type === 'null' || right.type === 'undefined')
-    ) {
-      // special case for null/undefined being functionally the same
-      conditionalResult = conditional.value.true;
-    } else if (left.type === right.type) {
-      if (left.const && right.const) {
-        if (left.const === right.const) {
-          conditionalResult = conditional.value.true;
-        }
-      } else {
-        conditionalResult = conditional.value.true;
-      }
-    }
+    const conditionalResult = conditional.value.false;
 
     // Compose first level generics here since `conditionalResult` won't have them
     if (isGenericNodeType(conditional)) {

--- a/xlr/utils/src/validation-helpers.ts
+++ b/xlr/utils/src/validation-helpers.ts
@@ -190,10 +190,16 @@ export function computeEffectiveObject(
   }
 
   if (newObject.additionalProperties && operand.additionalProperties) {
-    newObject.additionalProperties = {
-      type: 'and',
-      and: [newObject.additionalProperties, operand.additionalProperties],
-    };
+    if (
+      !isPrimitiveTypeNode(newObject.additionalProperties) ||
+      !isPrimitiveTypeNode(operand.additionalProperties) ||
+      newObject.additionalProperties.type !== operand.additionalProperties.type
+    ) {
+      newObject.additionalProperties = {
+        type: 'and',
+        and: [newObject.additionalProperties, operand.additionalProperties],
+      };
+    }
   } else if (operand.additionalProperties) {
     newObject.additionalProperties = operand.additionalProperties;
   }


### PR DESCRIPTION
Misc improvements found when benchmarking XLR validations

### Improperly resolving `Exlcudes` keyword when converting to XLR
Currently, types that use the `Excludes` keywords results in a mapped type getting produced that may or may not resolve well at runtime. Since this is a keyword that we can parse at compile time like `Omit` or `Pick` we should be handling this directly. 

### Precompute and Cache Types
When we access a type from the SDK, we do some computations to figure out what the effective object is once `extends` and generics are filled in. We don't need to do that work every time if the types in the SDK have not changed so we can cache those results and return them instead. 

### Instantiate LSP Once When Validating Content
Previously, an LSP was instantiated per file being validated, this lead to a lot of overhead when validating multiple files and, given the amount of XLR data being loaded, proved to be a bottleneck. Using a single LSP shared in every file validation process showed a ~3x performance increase in initial testing. 

### Missing Asset/View XLR Behavior
Previously, if an XLR definition for an Asset or a View was treated as a warning. In reality this should be treated as an error as its more likely a content issue than an issue with the source XLRs. 

### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Properly parse `Excludes` keyword when compiling XLRs
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.2--canary.63.1250</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.4.2--canary.63.1250
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
