### PR TITLE
8630-playa: DSL Schema stuff to OS tools

### DIFF
--- a/language/dsl/src/__tests__/util.test.tsx
+++ b/language/dsl/src/__tests__/util.test.tsx
@@ -1,0 +1,25 @@
+import { getObjectReferences } from '../utils';
+
+describe('Testing the "getObjectReferences" helper that creates same property references into a new object', () => {
+  it('should return the object properties in referenced format', () => {
+    const dataTypes = {
+      BooleanType: {
+        type: 'BooleanType',
+      },
+    };
+
+    const validators = {
+      required: {
+        type: 'required',
+      },
+    };
+
+    const dataReferences = getObjectReferences(dataTypes);
+    const validatorReferences = getObjectReferences(validators);
+
+    expect(dataReferences.BooleanTypeRef).toStrictEqual({
+      type: 'BooleanType',
+    });
+    expect(validatorReferences.requiredRef).toStrictEqual({ type: 'required' });
+  });
+});

--- a/language/dsl/src/compiler/types.ts
+++ b/language/dsl/src/compiler/types.ts
@@ -10,6 +10,7 @@ import type {
 } from '@player-ui/types';
 import type { JsonType } from 'react-json-reconciler';
 import type { RemoveUnknownIndex, AddUnknownIndex } from '../types';
+import type { DSLSchema } from '../types';
 
 export type NavigationFlowReactViewState = Omit<
   NavigationFlowViewState,
@@ -49,11 +50,10 @@ export type FlowWithReactViews = AddUnknownIndex<
   }
 >;
 
-export type DSLFlow = FlowWithReactViews;
-
-export interface DSLSchema {
-  [key: string]: Schema.DataType | DSLSchema;
-}
+export type DSLFlow = Omit<FlowWithReactViews, 'schema'> & {
+  /** A DSL compliant schema */
+  schema?: DSLSchema;
+};
 
 export type SerializeType = 'view' | 'flow' | 'schema' | 'navigation';
 

--- a/language/dsl/src/types.ts
+++ b/language/dsl/src/types.ts
@@ -2,6 +2,8 @@ import type {
   Asset,
   Expression,
   Navigation as PlayerNav,
+  Schema,
+  Validation,
 } from '@player-ui/types';
 import type {
   BindingTemplateInstance,
@@ -86,4 +88,26 @@ export interface toJsonOptions {
    * default is 'applicability'
    */
   propertiesToSkip?: string[];
+}
+
+export type DataTypeReference<
+  DataTypeProp = string,
+  ValidationRef = Validation.Reference,
+  SymbolType = void
+> =
+  | (Omit<Schema.DataType, 'type' | 'validation'> & {
+      /** Handled data type */
+      type: DataTypeProp;
+      /** Data type validation refs */
+      validation?: ValidationRef[];
+    })
+  | SymbolType
+  | [SymbolType];
+
+export interface DSLSchema<DataTypeRef = DataTypeReference> {
+  [key: string]:
+    | [DataTypeRef]
+    | DataTypeRef
+    | [DSLSchema<DataTypeRef>]
+    | DSLSchema<DataTypeRef>;
 }

--- a/language/dsl/src/utils.tsx
+++ b/language/dsl/src/utils.tsx
@@ -146,3 +146,20 @@ export function flattenChildren(children: React.ReactNode): ReactChildArray {
     return flatChildren;
   }, []);
 }
+
+/** Generates object reference properties from the provided object */
+export function getObjectReferences<
+  OriginalPropertiesObject extends Record<string, unknown>,
+  ReferencesPropertyObject extends Record<string, unknown>
+>(propertiesObject: OriginalPropertiesObject) {
+  const result: any = {};
+
+  for (const itemProp in propertiesObject) {
+    if (Object.prototype.hasOwnProperty.call(propertiesObject, itemProp)) {
+      const refName = `${itemProp}Ref`;
+      result[refName as keyof ReferencesPropertyObject] = { type: itemProp };
+    }
+  }
+
+  return result as ReferencesPropertyObject;
+}


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Moving Player DSLSchema type into OS.

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->