### PR TITLE
Fix loading XLRs from node_modules in webpack plugin

### DIFF
--- a/xlr/asset-docgen-webpack-plugin/src/index.ts
+++ b/xlr/asset-docgen-webpack-plugin/src/index.ts
@@ -42,10 +42,12 @@ export default class AssetDocgenPlugin {
     // Glob all XLRs manifests available in repo
     const manifests = globby.sync(["**/dist/xlr/manifest.json"]);
     // load manifests into sdk
-    manifests.forEach((manifest) => {
-      const packageName = manifest.split("/dist/")[0];
-      sdk.loadDefinitionsFromDisk(path.join(".", packageName, "dist"));
-    });
+    manifests
+      .filter((manifest) => !manifest.includes("node_modules"))
+      .forEach((manifest) => {
+        const packageName = manifest.split("/dist/")[0];
+        sdk.loadDefinitionsFromDisk(path.join(".", packageName, "dist"));
+      });
     const assetSources = sdk.listTypes().map((asset) => {
       return [
         asset.name,


### PR DESCRIPTION

### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
FIx XLR Webpack plugin loading XLRs from `node_modules`