### PR TITLE
Use New Rules to Skip Custom Entrypoint Insertion for CLI

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(name = "player-tools", version = "1.0")
 
 bazel_dep(name = "rules_player")
 
-git_override(module_name = "rules_player", remote = "https://github.com/player-ui/rules_player.git", commit = "24f4cd03e0f13438c7bd145c966eb30bee9773f2")
+git_override(module_name = "rules_player", remote = "https://github.com/player-ui/rules_player.git", commit = "394aaebd9b50fab3719112d89b85e20437bd58e9")
 # local_path_override(module_name = "rules_player", path = "../rules_player")
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.39.0")

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -88,6 +88,7 @@ create_package_json(
     substitutions = {
         "0.0.0-PLACEHOLDER": "{STABLE_VERSION}",
     },
+    custom_entrypoints = True,
 )
 
 oclif_bin.oclif(

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@player-tools/cli",
   "version": "0.0.0-PLACEHOLDER",
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "bin",
     "dist",


### PR DESCRIPTION
### Change Type (required)

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Fix custom entry points being overridden in CLI package