### PR TITLE
Fix issues with storybook plugin and storybook 6.5.x

### DIFF
--- a/xlr/asset-docgen-webpack-plugin/src/index.ts
+++ b/xlr/asset-docgen-webpack-plugin/src/index.ts
@@ -66,11 +66,13 @@ export default class AssetDocgenPlugin {
         operations: [
           new ConcatOperation(
             "end",
-            `export const __asset__docs = ${JSON.stringify(
+            `export const __asset__docs_${assetName} = ${JSON.stringify(
               covertXLRtoAssetDoc(
-                sdk.getType(assetName) as NamedType<ObjectType>
+                sdk.getType(assetName, {
+                  getRawType: true,
+                }) as NamedType<ObjectType>
               )
-            )}`
+            )};`
           ),
         ],
       })


### PR DESCRIPTION
### Change Type (required)
- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Storybook Plugin - Fix linting issues, doc export collision if two XLRs are exported from the same package, and not having player xlr types loaded when parsing types