### PR TITLE
Update Circle Configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,7 @@ parameters:
     default: false
 
 orbs:
-  macos: circleci/macos@2
-  android: circleci/android@2.0
-  codecov: codecov/codecov@3.2.2
+  codecov: codecov/codecov@4.0.1
 
 executors:
   base:
@@ -94,27 +92,6 @@ jobs:
       - attach_workspace:
           at: ~/tools
 
-      - run: bazel test --config=ci -- //...
-
-      - run:
-          when: always
-          command: |
-            RESULTS_DIR=_test_results
-            find -L ./bazel-testlogs -name test.xml | while read line
-            do
-              mkdir -p $RESULTS_DIR/$(dirname $line)
-              cp $line $RESULTS_DIR/$(dirname $line)
-            done
-
-      - store_test_results:
-          path: _test_results
-
-  coverage:
-    executor: base
-    steps:
-      - attach_workspace:
-          at: ~/tools
-
       - restore_cache:
           keys:
             - v1-bazel-cache-core-{{ .Branch }}-{{ .Revision }}
@@ -175,10 +152,6 @@ workflows:
           requires:
             - build
 
-      - coverage:
-          requires:
-            - build
-
   build_and_test_pr_fork:
     jobs:
       - setup:
@@ -194,10 +167,6 @@ workflows:
             - setup
 
       - test:
-          requires:
-            - build
-
-      - coverage:
           requires:
             - build
 
@@ -220,16 +189,11 @@ workflows:
           requires:
             - build
 
-      - coverage:
-          requires:
-            - build
-
       - release:
           context:
             - Publish
           requires:
             - test
-            - coverage
 
   release:
     when:
@@ -245,13 +209,8 @@ workflows:
           requires:
             - build
 
-      - coverage:
-          requires:
-            - build
-
       - release:
           context:
             - Publish
           requires:
             - test
-            - coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: false
 
 orbs:
-  codecov: codecov/codecov@4.0.1
+  codecov: codecov/codecov@3.2.2
 
 executors:
   base:


### PR DESCRIPTION
Maintenance updates to the circle config to 

- Skip redundant test/coverage steps which should cut ~3m from the build