### PR TITLE
Fix Oclif CLI Plugins not Registering

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,8 +2,8 @@ module(name = "player-tools", version = "1.0")
 
 bazel_dep(name = "rules_player")
 
-git_override(module_name = "rules_player", remote = "https://github.com/player-ui/rules_player.git", commit = "56d4319435f0cafe7e6d9b90223e74d3b4dc25ef")
-# local_path_override(module_name = "rules_player", path = "../rules_player")
+git_override(module_name = "rules_player", remote = "https://github.com/player-ui/rules_player.git", commit = "d003efcacc5343ad6021a0ba5bb029607d31f8fb")
+#local_path_override(module_name = "rules_player", path = "../rules_player")
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
 bazel_dep(name = "aspect_rules_js", version = "1.38.0")

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -1,155 +1,59 @@
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//:oclif/package_json.bzl", oclif_bin = "bin")
-load("@rules_player//javascript:defs.bzl", "create_package_json", "eslint_test", "vitest_test")
-load("//helpers:defs.bzl", "vitest_config")
+load("@rules_player//javascript:defs.bzl", "oclif_pipeline")
+load("//helpers:defs.bzl", "tsup_config", "vitest_config")
 
 npm_link_all_packages(name = "node_modules")
 
+tsup_config(name = "tsup_config")
+
 vitest_config(name = "vitest_config")
 
-dev_dependencies = [
-    "//:node_modules/@types/babel__register",
-    "//:node_modules/@types/fs-extra",
-    "//:node_modules/@types/mkdirp",
-    "//:node_modules/std-mocks",
-    "//:node_modules/@types/std-mocks",
-    "//:node_modules/vitest",
-]
-
-dependencies = [
-    "//:node_modules/react",
-    "//:node_modules/tapable-ts",
-    "//:node_modules/@babel/register",
-    "//:node_modules/@babel/preset-env",
-    "//:node_modules/@babel/preset-react",
-    "//:node_modules/@babel/preset-typescript",
-    "//:node_modules/@babel/plugin-transform-react-jsx-source",
-    "//:node_modules/@oclif/core",
-    "//:node_modules/@oclif/plugin-legacy",
-    "//:node_modules/chalk",
-    "//:node_modules/cosmiconfig",
-    "//:node_modules/cross-fetch",
-    "//:node_modules/dlv",
-    "//:node_modules/easy-table",
-    "//:node_modules/elegant-spinner",
-    "//:node_modules/figures",
-    "//:node_modules/fs-extra",
-    "//:node_modules/globby",
-    "//:node_modules/log-symbols",
-    "//:node_modules/log-update",
-    "//:node_modules/mkdirp",
-    "//:node_modules/vscode-languageserver-textdocument",
-    "//:node_modules/vscode-languageserver-types",
-    "//:node_modules/typescript",
-    "//:node_modules/tslib",
-    ":node_modules/@player-tools/dsl",
-    ":node_modules/@player-tools/json-language-service",
-    ":node_modules/@player-tools/xlr",
-    ":node_modules/@player-tools/xlr-sdk",
-    ":node_modules/@player-tools/xlr-utils",
-    ":node_modules/@player-tools/xlr-converters",
-]
-
-all_deps = dependencies + dev_dependencies
-
-ts_config(
-    name = "tsconfig",
-    src = "tsconfig.json",
+oclif_pipeline(
+    package_name = "@player-tools/cli",
+    test_deps = [
+        "//:node_modules",
+        "//:vitest_config",
+    ],
     deps = [
-        "//:tsconfig",
+        "//:node_modules/react",
+        "//:node_modules/tapable-ts",
+        "//:node_modules/@babel/register",
+        "//:node_modules/@babel/preset-env",
+        "//:node_modules/@babel/preset-react",
+        "//:node_modules/@babel/preset-typescript",
+        "//:node_modules/@babel/plugin-transform-react-jsx-source",
+        "//:node_modules/@oclif/core",
+        "//:node_modules/@oclif/plugin-legacy",
+        "//:node_modules/@oclif/plugin-plugins",
+        "//:node_modules/chalk",
+        "//:node_modules/cosmiconfig",
+        "//:node_modules/cross-fetch",
+        "//:node_modules/dlv",
+        "//:node_modules/easy-table",
+        "//:node_modules/elegant-spinner",
+        "//:node_modules/figures",
+        "//:node_modules/fs-extra",
+        "//:node_modules/globby",
+        "//:node_modules/log-symbols",
+        "//:node_modules/log-update",
+        "//:node_modules/mkdirp",
+        "//:node_modules/vscode-languageserver-textdocument",
+        "//:node_modules/vscode-languageserver-types",
+        "//:node_modules/typescript",
+        "//:node_modules/tslib",
+        ":node_modules/@player-tools/dsl",
+        ":node_modules/@player-tools/json-language-service",
+        ":node_modules/@player-tools/xlr",
+        ":node_modules/@player-tools/xlr-sdk",
+        ":node_modules/@player-tools/xlr-utils",
+        ":node_modules/@player-tools/xlr-converters",
     ],
-)
-
-ts_project(
-    name = "player-cli-build",
-    srcs = glob(
-        [
-            "bin/**/*",
-            "src/**/*",
-        ],
-        exclude = [
-            "**/__tests__/*",
-            "**/*.test.*",
-        ],
-    ),
-    declaration = True,
-    out_dir = "dist",
-    root_dir = "src",
-    transpiler = "tsc",
-    tsconfig = ":tsconfig",
-    validate = False,
-    deps = all_deps,
-)
-
-create_package_json(
-    name = "player-cli-package_json",
-    base_package_json = "package.json",
-    dependencies = dependencies,
-    root_package_json = "//:package.json",
-    substitutions = {
-        "0.0.0-PLACEHOLDER": "{STABLE_VERSION}",
-    },
-    custom_entrypoints = True,
-)
-
-oclif_bin.oclif(
-    name = "player-cli-manifest",
-    srcs = [
-        "package.json",
-        ":player-cli-build",
-        ":player-cli-package_json",
-    ],
-    outs = ["oclif.manifest.json"],
-    args = ["manifest"],
-    chdir = package_name(),
-)
-
-js_library(
-    name = "player-cli-bundle",
-    srcs = [
-        ":player-cli-build",
-        ":player-cli-manifest",
-        ":player-cli-package_json",
-    ] + glob(["bin/*"]),
-    deps = all_deps,
-)
-
-vitest_test(
-    name = "player-cli-unit",
-    config = ":vitest_config",
-    data = glob(["src/**/*"]) + all_deps + ["//:vitest_config"],
-    node_modules = "//:node_modules",
-)
-
-eslint_test(
-    name = "player-cli-lint",
-    srcs = glob(["src/**/*"]),
-    data = glob(["src/**/*"]) + all_deps + ["//:eslint_config"],
-    node_modules = "//:node_modules",
-)
-
-npm_package(
-    name = "cli",
-    srcs = [
-        "README.md",
-        ":player-cli-bundle",
-    ],
-    allow_overwrites = True,
-    package = "@player-tools/cli",
-    replace_prefixes = {
-        "player-cli-package_json": "package",
-    },
-    visibility = ["//visibility:public"],
-)
-
-js_binary(
-    name = "cli.npm-publish",
-    chdir = package_name() + "/cli",
-    data = [":cli"],
-    entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",
-    # required to make npm to be available in PATH
-    include_npm = True,
+    build_deps = [
+        "//:node_modules/@types/babel__register",
+        "//:node_modules/@types/fs-extra",
+        "//:node_modules/@types/mkdirp",
+        "//:node_modules/std-mocks",
+        "//:node_modules/@types/std-mocks",
+        "//:node_modules/vitest",
+    ]
 )

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,14 +12,14 @@
     "bin": "player",
     "dirname": "player",
     "topicSeparator": " ",
-    "commands": "dist/commands"
+    "commands": "dist/commands",
+    "plugins": [
+      "@oclif/plugin-plugins"
+    ]
   },
   "bin": {
     "player": "bin/run"
   },
-  "plugins": [
-    "@oclif/plugin-plugins"
-  ],
   "dependencies": {
     "@player-tools/dsl": "workspace:*",
     "@player-tools/json-language-service": "workspace:*",


### PR DESCRIPTION
The conflg and dependency for the `@oclif/plugins-plugin` was misapplied so plugins were not able to be registered to the oclif plugin. 

### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
- Fix Oclif plugins not registering
- Use shared Oclif macro for CLI build
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.2--canary.94.2360</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.5.2--canary.94.2360
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
