### PR TITLE
Handle Template Strings Earlier in DSL Compilation

### DIFF
--- a/language/dsl/src/__tests__/edge-cases.test.tsx
+++ b/language/dsl/src/__tests__/edge-cases.test.tsx
@@ -1,6 +1,6 @@
 import { test, expect } from "vitest";
 import React from "react";
-import { render, expression as e } from "..";
+import { render, expression as e, makeBindingsForObject } from "..";
 import { Collection, Input, Text } from "./helpers/asset-library";
 
 test("works with a Component that returns a Fragment of items", async () => {
@@ -78,4 +78,48 @@ test("handles invalid expressions", async () => {
   await expect(render(<App />)).rejects.toThrow(
     'Unclosed quote after "" at character 9'
   );
+});
+
+test("handles using intermediate schema values as bindings", async () => {
+  const model = {
+    some: {
+      path: [
+        {
+          of: {
+            things: {
+              type: "StringType",
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const schema = makeBindingsForObject(model);
+
+  const App = () => {
+    return (
+      <Collection>
+        <Collection.Values>
+          <Text value={schema.some.path} />
+        </Collection.Values>
+      </Collection>
+    );
+  };
+
+  expect((await render(<App />)).jsonValue).toMatchInlineSnapshot(`
+    {
+      "id": "root",
+      "type": "collection",
+      "values": [
+        {
+          "asset": {
+            "id": "values-0",
+            "type": "text",
+            "value": "{{some.path}}",
+          },
+        },
+      ],
+    }
+  `);
 });

--- a/language/dsl/src/utils.tsx
+++ b/language/dsl/src/utils.tsx
@@ -18,14 +18,6 @@ export function toJsonElement(
 ): React.ReactElement {
   const indexProp = typeof indexOrKey === "number" ? { key: indexOrKey } : null;
 
-  if (Array.isArray(value)) {
-    return (
-      <array {...indexProp}>
-        {value.map((item, idx) => toJsonElement(item, idx, options))}
-      </array>
-    );
-  }
-
   /** Allow users to pass in BindingTemplateInstance and ExpressionTemplateInstance directly without turning them into strings first */
   if (isTemplateStringInstance(value)) {
     if (
@@ -36,6 +28,14 @@ export function toJsonElement(
     }
 
     return <value {...indexProp}>{value.toRefString()}</value>;
+  }
+
+  if (Array.isArray(value)) {
+    return (
+      <array {...indexProp}>
+        {value.map((item, idx) => toJsonElement(item, idx, options))}
+      </array>
+    );
   }
 
   if (typeof value === "object" && value !== null) {


### PR DESCRIPTION
Currently, if you try and use an intermediate part of the schema in content, it may or may not serialize correctly. For example the binding `some` from the schema 

```typescript 
const schema = {
    some: [
        {
            value: {...},
            value2: {...}
        }
    ]
}
```

was used, an error would be thrown [here](https://github.com/player-ui/tools/blob/845938fa01eceef2aedb1748a8810814815dca16/language/dsl/src/utils.tsx#L21) as `makeBindingsForObject` would proxy that element into an _array-like_ object that would be caught by that check but wouldn't actually be serializable. With this change, we move the check for if the value being processed is a `TemplateStringType` that we should handle directly before processing it as a regular piece of content.  

While technically loading complex data structures from the data model is possible, it should be considered unsafe. The validator will throw an error as the final content doesn't conform to the expected shape from the types. Better supporting this would be possible, however it is out of the scope of this fix. From purely a DSL feature level, you should be able to create any content you would be able to via authoring JSON directly. 


### Change Type 
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
DSL - Allow intermediate binding paths to be used in content