### PR TITLE
Fix Regression on Validation of Keys with Escaped Characters

### DIFF
--- a/xlr/utils/src/__tests__/validation-helpers.test.ts
+++ b/xlr/utils/src/__tests__/validation-helpers.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe } from "vitest";
 import type { ObjectType } from "@player-tools/xlr";
-import { computeEffectiveObject } from "../validation-helpers";
+import { computeEffectiveObject, makePropertyMap } from "../validation-helpers";
+import { parseTree } from "jsonc-parser";
 
 describe("computeEffectiveObject tests", () => {
   test("mixed test", () => {
@@ -103,5 +104,38 @@ describe("computeEffectiveObject tests", () => {
     };
 
     expect(computeEffectiveObject(type1, type2)).toMatchSnapshot();
+  });
+});
+
+describe("makePropertyMap tests", () => {
+  test("basic test", () => {
+    const jsonObject = {
+      key1: "value",
+      key2: true,
+      key3: 1,
+    };
+
+    const treeObject = parseTree(JSON.stringify(jsonObject));
+
+    const propertyMap = makePropertyMap(treeObject);
+
+    expect(propertyMap.get("key1")?.value).toStrictEqual("value");
+    expect(propertyMap.get("key2")?.value).toStrictEqual(true);
+    expect(propertyMap.get("key3")?.value).toStrictEqual(1);
+  });
+
+  test("escaped key", () => {
+    const jsonObject = {
+      "some-key": "value",
+      // eslint-disable-next-line prettier/prettier
+      'some-otherkey': "value",
+    };
+
+    const treeObject = parseTree(JSON.stringify(jsonObject));
+
+    const propertyMap = makePropertyMap(treeObject);
+
+    expect(propertyMap.get("'some-key'")?.value).toStrictEqual("value");
+    expect(propertyMap.get("'some-otherkey'")?.value).toStrictEqual("value");
   });
 });

--- a/xlr/utils/src/validation-helpers.ts
+++ b/xlr/utils/src/validation-helpers.ts
@@ -22,7 +22,8 @@ export interface PropertyNode {
 export function propertyToTuple(node: Node): PropertyNode {
   let key = node.children?.[0].value as string;
   if (key.includes("-")) {
-    key = `"${key}"`;
+    // XLR outputs all escaped properties with single quotes
+    key = `'${key}'`;
   }
 
   return {


### PR DESCRIPTION
Fixes a regression when validating an object where one key is escaped. As XLR will output escaped properties with a single quote, if the mapped properties set has the escaped key in double quotes it will not find the property and thus may lead to an error. This bug was most likely introduced when we changed the prettier config to prefer double quotes over single quotes. The conversion must not have ignored quotes in string templates. 

### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
XLR - Fixes validation of objects where a property is escaped using single/double quotes and the property is required or the object doesn't allow additional properties. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.1--canary.110.2690</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.6.1--canary.110.2690
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
