### PR TITLE
Fix Parsing Indexed Access Types with Parentheses 

### DIFF
--- a/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/ts-to-common.test.ts.snap
@@ -1186,6 +1186,27 @@ exports[`Type with typeof > Indexing 1`] = `
     "title": "options",
     "type": "or",
   },
+  {
+    "genericTokens": undefined,
+    "name": "options2",
+    "or": [
+      {
+        "const": "one",
+        "type": "string",
+      },
+      {
+        "const": "two",
+        "type": "string",
+      },
+      {
+        "const": "three",
+        "type": "string",
+      },
+    ],
+    "source": "filename.ts",
+    "title": "options2",
+    "type": "or",
+  },
 ]
 `;
 

--- a/xlr/converters/src/__tests__/ts-to-common.test.ts
+++ b/xlr/converters/src/__tests__/ts-to-common.test.ts
@@ -476,7 +476,7 @@ describe("Type with typeof", () => {
     ] as const
     
     export type options = typeof options[number];
-
+    export type options2 = (typeof options)[number];
     `;
 
     const { sf, tc } = setupTestEnv(sc);

--- a/xlr/converters/src/ts-to-xlr.ts
+++ b/xlr/converters/src/ts-to-xlr.ts
@@ -453,7 +453,13 @@ export class TsConverter {
         }
       }
 
-      if (ts.isTypeQueryNode(node.objectType)) {
+      let queryNode = node.objectType;
+      // handle cases where the object being accessed is wrapped in () because of linting
+      if (ts.isParenthesizedTypeNode(node.objectType)) {
+        queryNode = node.objectType.type;
+      }
+
+      if (ts.isTypeQueryNode(queryNode)) {
         const elements = this.tsNodeToType(node.objectType) as TupleType;
         return {
           type: "or",
@@ -462,7 +468,7 @@ export class TsConverter {
       }
 
       this.context.throwError(
-        `Error: could not solve IndexedAccessType ${node.getFullText()}`
+        `Error: could not solve IndexedAccessType: ${node.getFullText()}`
       );
     }
 


### PR DESCRIPTION
When parsing `IndexedAccessType` nodes, the current check of the `objectType` property  being  a `TypeQuery` node doesn't handle the cases where it may be wrapped in a `ParenthesizedTypeNode`. While functionally the same, the check doesn't account for it and causes an error to be thrown. This adds a simple check for that type of node and will use its child if present. 

### Change Type
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
XLR - Fixed compilation of `IndexedAccesNodes `that use parentheses around the first element. 