### PR TITLE
PLAYA8916-default player should go to current selected player on refresh

### DIFF
--- a/devtools/client/src/state/reducer.ts
+++ b/devtools/client/src/state/reducer.ts
@@ -20,7 +20,7 @@ export const reducer = (
         } = transaction;
         dset(draft, ["current", "player"], sender);
         dset(draft, ["current", "plugin"], plugins[Object.keys(plugins)[0]].id);
-
+ 
         dset(draft, ["players", sender, "plugins"], plugins);
         dset(draft, ["players", sender, "active"], true);
       });

--- a/devtools/client/src/state/reducer.ts
+++ b/devtools/client/src/state/reducer.ts
@@ -18,17 +18,8 @@ export const reducer = (
           sender,
           payload: { plugins },
         } = transaction;
-        const { player, plugin } = draft.current;
-
-        if (!player && !plugin) {
-          // if there is no player and plugin selected, select the first one:
-          dset(draft, ["current", "player"], sender);
-          dset(
-            draft,
-            ["current", "plugin"],
-            plugins[Object.keys(plugins)[0]].id
-          );
-        }
+        dset(draft, ["current", "player"], sender);
+        dset(draft, ["current", "plugin"], plugins[Object.keys(plugins)[0]].id);
 
         dset(draft, ["players", sender, "plugins"], plugins);
         dset(draft, ["players", sender, "active"], true);

--- a/devtools/client/src/state/reducer.ts
+++ b/devtools/client/src/state/reducer.ts
@@ -20,7 +20,7 @@ export const reducer = (
         } = transaction;
         dset(draft, ["current", "player"], sender);
         dset(draft, ["current", "plugin"], plugins[Object.keys(plugins)[0]].id);
- 
+
         dset(draft, ["players", sender, "plugins"], plugins);
         dset(draft, ["players", sender, "active"], true);
       });


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
We only change the inspected player tools if there was no player being inspected; however we should default to the most recent player.



### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->