### PR TITLE
Devtools- panel layout fix and version upgrade

### DIFF
--- a/devtools/client/src/panel/index.tsx
+++ b/devtools/client/src/panel/index.tsx
@@ -156,7 +156,7 @@ export const Panel = ({
                 <Flex direction="column" marginTop="4">
                   <Flex gap={"8"}>
                     <FormControl>
-                      <FormLabel>Test Player2</FormLabel>
+                      <FormLabel>Player</FormLabel>
                       <Select
                         id="player"
                         value={state.current.player || ""}
@@ -186,9 +186,9 @@ export const Panel = ({
                       </Select>
                     </FormControl>
                   </Flex>
-                  <Container marginY="6">
+                  <Flex>
                     <Component />
-                  </Container>
+                  </Flex>
                   <details>
                     <summary>Debug</summary>
                     <pre style={{ maxHeight: "30vh", overflow: "scroll" }}>

--- a/devtools/client/src/panel/index.tsx
+++ b/devtools/client/src/panel/index.tsx
@@ -150,49 +150,53 @@ export const Panel = ({
     <ChakraProvider theme={theme}>
       <ThemeProvider colorScheme="dark">
         <ErrorBoundary fallbackRender={fallbackRender}>
-          <VStack w="100vw" h="100vh">
+          <Flex direction="column" w="100vw" h="100vh" alignItems={"normal"}>
             {state.current.player ? (
-              <Flex direction="column" marginTop="4">
-                <HStack spacing="4">
-                  <FormControl>
-                    <FormLabel>Player</FormLabel>
-                    <Select
-                      id="player"
-                      value={state.current.player || ""}
-                      onChange={(event) => selectPlayer(event.target.value)}
-                    >
-                      {Object.keys(state.players).map((playerID) => (
-                        <option key={playerID} value={playerID}>
-                          {playerID}
-                        </option>
-                      ))}
-                    </Select>
-                  </FormControl>
-                  <FormControl>
-                    <FormLabel>Plugin</FormLabel>
-                    <Select
-                      id="plugin"
-                      value={state.current.plugin || ""}
-                      onChange={(event) => selectPlugin(event.target.value)}
-                    >
-                      {Object.keys(
-                        state.players[state.current.player].plugins
-                      ).map((pluginID) => (
-                        <option key={pluginID} value={pluginID}>
-                          {pluginID}
-                        </option>
-                      ))}
-                    </Select>
-                  </FormControl>
-                </HStack>
-                <Container marginY="6">
-                  <Component />
-                </Container>
-                <details>
-                  <summary>Debug</summary>
-                  <pre>{JSON.stringify(state, null, 2)}</pre>
-                </details>
-              </Flex>
+              <Container minWidth={"100%"}>
+                <Flex direction="column" marginTop="4">
+                  <Flex gap={"8"}>
+                    <FormControl>
+                      <FormLabel>Test Player2</FormLabel>
+                      <Select
+                        id="player"
+                        value={state.current.player || ""}
+                        onChange={(event) => selectPlayer(event.target.value)}
+                      >
+                        {Object.keys(state.players).map((playerID) => (
+                          <option key={playerID} value={playerID}>
+                            {playerID}
+                          </option>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel>Plugin</FormLabel>
+                      <Select
+                        id="plugin"
+                        value={state.current.plugin || ""}
+                        onChange={(event) => selectPlugin(event.target.value)}
+                      >
+                        {Object.keys(
+                          state.players[state.current.player].plugins
+                        ).map((pluginID) => (
+                          <option key={pluginID} value={pluginID}>
+                            {pluginID}
+                          </option>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Flex>
+                  <Container marginY="6">
+                    <Component />
+                  </Container>
+                  <details>
+                    <summary>Debug</summary>
+                    <pre style={{ maxHeight: "30vh", overflow: "scroll" }}>
+                      {JSON.stringify(state, null, 2)}
+                    </pre>
+                  </details>
+                </Flex>
+              </Container>
             ) : (
               <Flex justifyContent="center" padding="6">
                 <Text>
@@ -204,7 +208,7 @@ export const Panel = ({
                 </Text>
               </Flex>
             )}
-          </VStack>
+          </Flex>
         </ErrorBoundary>
       </ThemeProvider>
     </ChakraProvider>

--- a/devtools/plugins/desktop/test-env/setup.sh
+++ b/devtools/plugins/desktop/test-env/setup.sh
@@ -18,7 +18,7 @@ VERDACCIO_REGISTRY="http://localhost:4873"
 PLUGINS=("@player-tools/devtools-basic-web-plugin")
 
 # Define browser-devtools depenedencies
-BROWSER_DEVTOOLS_DEPS=("@player-ui/pubsub-plugin" "dequal" "@player-tools/devtools-client@0.0.0-ME5" "@player-tools/devtools-messenger" "@player-tools/devtools-types")
+BROWSER_DEVTOOLS_DEPS=("@player-ui/pubsub-plugin" "dequal" "@player-tools/devtools-client" "@player-tools/devtools-messenger" "@player-tools/devtools-types")
 
 # Run publish-to-verdaccio.sh
 log_step "Running publish-to-verdaccio.sh..."

--- a/devtools/plugins/desktop/test-env/setup.sh
+++ b/devtools/plugins/desktop/test-env/setup.sh
@@ -18,7 +18,7 @@ VERDACCIO_REGISTRY="http://localhost:4873"
 PLUGINS=("@player-tools/devtools-basic-web-plugin")
 
 # Define browser-devtools depenedencies
-BROWSER_DEVTOOLS_DEPS=("@player-ui/pubsub-plugin" "dequal" "@player-tools/devtools-client" "@player-tools/devtools-messenger" "@player-tools/devtools-types")
+BROWSER_DEVTOOLS_DEPS=("@player-ui/pubsub-plugin" "dequal" "@player-tools/devtools-client@0.0.0-ME5" "@player-tools/devtools-messenger" "@player-tools/devtools-types")
 
 # Run publish-to-verdaccio.sh
 log_step "Running publish-to-verdaccio.sh..."

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@devtools-ds/object-parser": "^1.2.1",
     "@devtools-ds/table": "^1.2.1",
     "@devtools-ds/themes": "^1.2.1",
-    "@devtools-ui/plugin": "0.1.1",
+    "@devtools-ui/plugin": "0.2.0-next.2",
     "@emotion/styled": "^11",
     "@oclif/core": "1.9.0",
     "@oclif/errors": "^1.3.6",


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

This bumps the version of devtools and fixes the panel width. 
![Screenshot 2024-06-04 at 7 15 40 AM](https://github.com/player-ui/tools/assets/3643493/6e95b1b5-905c-465a-a9f3-a1765df75f7a)

Switched from stack to Flex ->
"The Stack component and the Flex component have their children spaced out evenly but the key difference is that the Stack won't span the entire width of the container whereas the Flex will."

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->