### PR TITLE
Fix Bug when Validating `null` literals

### DIFF
--- a/xlr/sdk/src/validator.ts
+++ b/xlr/sdk/src/validator.ts
@@ -274,7 +274,7 @@ export class XLRValidator {
 
         return typeof literalType.value === "string";
       case "null":
-        return literalType.value === "null";
+        return literalType.value === null;
       case "never":
         return literalType === undefined;
       case "any":


### PR DESCRIPTION
Check against `null` instead of `"null"` when validating a `NullType`

### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Validator - Properly validate `NullType` nodes against `null` literals