### PR TITLE
Fix Issue Validating Templates

### DIFF
--- a/language/json-language-service/src/__tests__/__snapshots__/service.test.ts.snap
+++ b/language/json-language-service/src/__tests__/__snapshots__/service.test.ts.snap
@@ -197,33 +197,3 @@ exports[`player language service > validation > throws AssetWrapper errors 1`] =
   },
 ]
 `;
-
-exports[`player language service completion basic object completions 1`] = `
-Array [
-  Object {
-    "documentation": "The text to display",
-    "kind": 10,
-    "label": "value",
-  },
-  {
-    "documentation": "Any modifiers on the text",
-    "kind": 10,
-    "label": "modifiers",
-  },
-  {
-    "documentation": "Evaluate the given expression (or boolean) and if falsy, remove this node from the tree. This is re-computed for each change in the data-model",
-    "kind": 10,
-    "label": "applicability",
-  },
-  Object {
-    "documentation": "Adds a comment for the given node",
-    "kind": 10,
-    "label": "_comment",
-  },
-  Object {
-    "documentation": "A list of templates to process for this node",
-    "kind": 10,
-    "label": "template",
-  },
-]
-`;

--- a/language/json-language-service/src/plugins/asset-wrapper-array-plugin.ts
+++ b/language/json-language-service/src/plugins/asset-wrapper-array-plugin.ts
@@ -26,9 +26,10 @@ const isInView = (node: ASTNode): boolean => {
 const checkTypesForAssetWrapper = (nodes: Array<NodeType>): boolean => {
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
-    if (node.type === "ref" && node.ref.includes("AssetWrapper")) return true;
-    if (node.type === "or") return checkTypesForAssetWrapper(node.or);
-    if (node.type === "and") return checkTypesForAssetWrapper(node.and);
+    if (node.type === "object" && node.title?.includes("AssetWrapper")) {
+      return true;
+    } else if (node.type === "or") return checkTypesForAssetWrapper(node.or);
+    else if (node.type === "and") return checkTypesForAssetWrapper(node.and);
   }
 
   return false;

--- a/language/json-language-service/src/plugins/asset-wrapper-array-plugin.ts
+++ b/language/json-language-service/src/plugins/asset-wrapper-array-plugin.ts
@@ -28,8 +28,11 @@ const checkTypesForAssetWrapper = (nodes: Array<NodeType>): boolean => {
     const node = nodes[i];
     if (node.type === "object" && node.title?.includes("AssetWrapper")) {
       return true;
-    } else if (node.type === "or") return checkTypesForAssetWrapper(node.or);
-    else if (node.type === "and") return checkTypesForAssetWrapper(node.and);
+    } else if (node.type === "or") {
+      return checkTypesForAssetWrapper(node.or);
+    } else if (node.type === "and") {
+      return checkTypesForAssetWrapper(node.and);
+    }
   }
 
   return false;

--- a/language/json-language-service/src/xlr/__tests__/__snapshots__/transform.test.ts.snap
+++ b/language/json-language-service/src/xlr/__tests__/__snapshots__/transform.test.ts.snap
@@ -241,6 +241,16 @@ exports[`Transform Tests > applyTemplateProperty Transform 1`] = `
       "node": {
         "description": "A list of templates to process for this node",
         "elementType": {
+          "genericArguments": [
+            {
+              "ref": "Asset",
+              "type": "ref",
+            },
+            {
+              "const": "secondaryChildren",
+              "type": "string",
+            },
+          ],
           "ref": "Template<Asset, "secondaryChildren">",
           "type": "ref",
         },

--- a/language/json-language-service/src/xlr/transforms.ts
+++ b/language/json-language-service/src/xlr/transforms.ts
@@ -140,6 +140,13 @@ export const applyTemplateProperty: TransformFunction = (node, capability) => {
                 ? value.node.elementType.ref
                 : value.node.elementType.name
             }, "${key}">`,
+            genericArguments: [
+              value.node.elementType,
+              {
+                type: "string",
+                const: key,
+              },
+            ],
           });
         }
       }

--- a/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
+++ b/xlr/converters/src/__tests__/__snapshots__/player.test.ts.snap
@@ -875,6 +875,7 @@ exports[`Player Types Export 1`] = `
     "elementType": {
       "additionalProperties": false,
       "description": "A single case statement to use in a switch",
+      "extends": undefined,
       "genericTokens": [
         {
           "constraints": {
@@ -1038,6 +1039,7 @@ exports[`Player Types Export 1`] = `
         "and": [
           {
             "additionalProperties": false,
+            "extends": undefined,
             "genericTokens": [
               {
                 "constraints": {
@@ -1061,6 +1063,7 @@ exports[`Player Types Export 1`] = `
                   "elementType": {
                     "additionalProperties": false,
                     "description": "A single case statement to use in a switch",
+                    "extends": undefined,
                     "genericTokens": [
                       {
                         "constraints": {
@@ -1163,6 +1166,7 @@ exports[`Player Types Export 1`] = `
         "and": [
           {
             "additionalProperties": false,
+            "extends": undefined,
             "genericTokens": [
               {
                 "constraints": {
@@ -1186,6 +1190,7 @@ exports[`Player Types Export 1`] = `
                   "elementType": {
                     "additionalProperties": false,
                     "description": "A single case statement to use in a switch",
+                    "extends": undefined,
                     "genericTokens": [
                       {
                         "constraints": {
@@ -1309,6 +1314,7 @@ exports[`Player Types Export 1`] = `
     "or": [
       {
         "additionalProperties": false,
+        "extends": undefined,
         "genericTokens": [
           {
             "constraints": {
@@ -1330,6 +1336,7 @@ exports[`Player Types Export 1`] = `
               "elementType": {
                 "additionalProperties": false,
                 "description": "A single case statement to use in a switch",
+                "extends": undefined,
                 "genericTokens": [
                   {
                     "constraints": {
@@ -1405,6 +1412,7 @@ exports[`Player Types Export 1`] = `
       },
       {
         "additionalProperties": false,
+        "extends": undefined,
         "genericTokens": [
           {
             "constraints": {
@@ -1426,6 +1434,7 @@ exports[`Player Types Export 1`] = `
               "elementType": {
                 "additionalProperties": false,
                 "description": "A single case statement to use in a switch",
+                "extends": undefined,
                 "genericTokens": [
                   {
                     "constraints": {
@@ -1868,6 +1877,7 @@ If the expression is a composite, the last expression executed is the return val
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
@@ -1904,6 +1914,7 @@ If the expression is a composite, the last expression executed is the return val
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "genericTokens": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
@@ -2000,6 +2011,7 @@ If the expression is a composite, the last expression executed is the return val
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
                                     "exp": {
@@ -2034,6 +2046,7 @@ If the expression is a composite, the last expression executed is the return val
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
                                     "exp": {
@@ -2112,6 +2125,7 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
                                     "exp": {
@@ -2146,6 +2160,7 @@ If this is a flow started from another flow, the outcome determines the flow tra
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
                                     "exp": {
@@ -2243,6 +2258,7 @@ The return value determines the transition to take",
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
                                     "exp": {
@@ -2277,6 +2293,7 @@ The return value determines the transition to take",
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
                                     "exp": {
@@ -2364,6 +2381,7 @@ The flow will wait for the embedded application to manage moving to the next sta
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
                                     "exp": {
@@ -2398,6 +2416,7 @@ The flow will wait for the embedded application to manage moving to the next sta
                                 {
                                   "additionalProperties": false,
                                   "description": "An object with an expression in it",
+                                  "extends": undefined,
                                   "name": "ExpressionObject",
                                   "properties": {
                                     "exp": {
@@ -3549,6 +3568,7 @@ So this explicity says there should never be an exp prop on a state node that"s 
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -3583,6 +3603,7 @@ So this explicity says there should never be an exp prop on a state node that"s 
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -3681,6 +3702,7 @@ So this explicity says there should never be an exp prop on a state node that"s 
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -3715,6 +3737,7 @@ So this explicity says there should never be an exp prop on a state node that"s 
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -3809,6 +3832,7 @@ So this explicity says there should never be an exp prop on a state node that"s 
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -3843,6 +3867,7 @@ So this explicity says there should never be an exp prop on a state node that"s 
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -3924,6 +3949,7 @@ The return value determines the transition to take",
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -3958,6 +3984,7 @@ The return value determines the transition to take",
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -4045,6 +4072,7 @@ The flow will wait for the embedded application to manage moving to the next sta
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -4079,6 +4107,7 @@ The flow will wait for the embedded application to manage moving to the next sta
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -4172,6 +4201,7 @@ The flow will wait for the embedded application to manage moving to the next sta
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -4206,6 +4236,7 @@ The flow will wait for the embedded application to manage moving to the next sta
             {
               "additionalProperties": false,
               "description": "An object with an expression in it",
+              "extends": undefined,
               "name": "ExpressionObject",
               "properties": {
                 "exp": {
@@ -4946,6 +4977,7 @@ The flow will wait for the embedded application to manage moving to the next sta
                   {
                     "additionalProperties": false,
                     "description": "An object with an expression in it",
+                    "extends": undefined,
                     "name": "ExpressionObject",
                     "properties": {
                       "exp": {
@@ -4980,6 +5012,7 @@ The flow will wait for the embedded application to manage moving to the next sta
                   {
                     "additionalProperties": false,
                     "description": "An object with an expression in it",
+                    "extends": undefined,
                     "name": "ExpressionObject",
                     "properties": {
                       "exp": {
@@ -6671,6 +6704,7 @@ This will be used to lookup the proper handler",
                   },
                   {
                     "additionalProperties": false,
+                    "extends": undefined,
                     "properties": {
                       "validation": {
                         "node": {
@@ -6679,6 +6713,7 @@ This will be used to lookup the proper handler",
                             "additionalProperties": {
                               "type": "unknown",
                             },
+                            "extends": undefined,
                             "name": "CrossfieldReference",
                             "properties": {
                               "dataTarget": {

--- a/xlr/converters/src/ts-to-xlr.ts
+++ b/xlr/converters/src/ts-to-xlr.ts
@@ -39,6 +39,7 @@ import {
   isTopLevelDeclaration,
   resolveConditional,
   applyExcludeToNodeType,
+  isPrimitiveTypeNode,
 } from "@player-tools/xlr-utils";
 import { ConversionError } from "./types";
 
@@ -359,7 +360,15 @@ export class TsConverter {
           false: this.convertTsTypeNode(node.falseType) as NodeType,
         },
       } as ConditionalType;
-      return resolveConditional(xlrNode);
+      // Resolve simple conditionals now, defer complex ones to runtime
+      if (
+        isPrimitiveTypeNode(xlrNode.check.left) &&
+        isPrimitiveTypeNode(xlrNode.check.right)
+      ) {
+        return resolveConditional(xlrNode);
+      } else {
+        return xlrNode;
+      }
     }
 
     if (ts.isTypeReferenceNode(node)) {

--- a/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
+++ b/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
@@ -1,921 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Basic Validation > Basic Validation By Name 1`] = `
-[
-  {
-    "message": "Expected type "string" but got "number"",
-    "node": {
-      "children": [
-        {
-          "length": 4,
-          "offset": 13,
-          "parent": [Circular],
-          "type": "string",
-          "value": "id",
-        },
-        {
-          "length": 1,
-          "offset": 19,
-          "parent": [Circular],
-          "type": "number",
-          "value": 1,
-        },
-      ],
-      "colonOffset": 17,
-      "length": 7,
-      "offset": 13,
-      "parent": {
-        "children": [
-          [Circular],
-          {
-            "children": [
-              {
-                "length": 6,
-                "offset": 28,
-                "parent": [Circular],
-                "type": "string",
-                "value": "type",
-              },
-              {
-                "length": 7,
-                "offset": 36,
-                "parent": [Circular],
-                "type": "string",
-                "value": "input",
-              },
-            ],
-            "colonOffset": 34,
-            "length": 15,
-            "offset": 28,
-            "parent": [Circular],
-            "type": "property",
-          },
-          {
-            "children": [
-              {
-                "length": 9,
-                "offset": 51,
-                "parent": [Circular],
-                "type": "string",
-                "value": "binding",
-              },
-              {
-                "length": 11,
-                "offset": 62,
-                "parent": [Circular],
-                "type": "string",
-                "value": "some.data",
-              },
-            ],
-            "colonOffset": 60,
-            "length": 22,
-            "offset": 51,
-            "parent": [Circular],
-            "type": "property",
-          },
-          {
-            "children": [
-              {
-                "length": 7,
-                "offset": 81,
-                "parent": [Circular],
-                "type": "string",
-                "value": "label",
-              },
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "length": 7,
-                        "offset": 100,
-                        "parent": [Circular],
-                        "type": "string",
-                        "value": "asset",
-                      },
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "length": 7,
-                                "offset": 121,
-                                "parent": [Circular],
-                                "type": "string",
-                                "value": "value",
-                              },
-                              {
-                                "length": 17,
-                                "offset": 130,
-                                "parent": [Circular],
-                                "type": "string",
-                                "value": "{{input.label}}",
-                              },
-                            ],
-                            "colonOffset": 128,
-                            "length": 26,
-                            "offset": 121,
-                            "parent": [Circular],
-                            "type": "property",
-                          },
-                        ],
-                        "length": 48,
-                        "offset": 109,
-                        "parent": [Circular],
-                        "type": "object",
-                      },
-                    ],
-                    "colonOffset": 107,
-                    "length": 57,
-                    "offset": 100,
-                    "parent": [Circular],
-                    "type": "property",
-                  },
-                ],
-                "length": 75,
-                "offset": 90,
-                "parent": [Circular],
-                "type": "object",
-              },
-            ],
-            "colonOffset": 88,
-            "length": 84,
-            "offset": 81,
-            "parent": [Circular],
-            "type": "property",
-          },
-        ],
-        "length": 165,
-        "offset": 5,
-        "type": "object",
-      },
-      "type": "property",
-    },
-    "type": "type",
-  },
-  {
-    "message": "Property "id" missing from type "Asset"",
-    "node": {
-      "children": [
-        {
-          "children": [
-            {
-              "length": 7,
-              "offset": 121,
-              "parent": [Circular],
-              "type": "string",
-              "value": "value",
-            },
-            {
-              "length": 17,
-              "offset": 130,
-              "parent": [Circular],
-              "type": "string",
-              "value": "{{input.label}}",
-            },
-          ],
-          "colonOffset": 128,
-          "length": 26,
-          "offset": 121,
-          "parent": [Circular],
-          "type": "property",
-        },
-      ],
-      "length": 48,
-      "offset": 109,
-      "parent": {
-        "children": [
-          {
-            "length": 7,
-            "offset": 100,
-            "parent": [Circular],
-            "type": "string",
-            "value": "asset",
-          },
-          [Circular],
-        ],
-        "colonOffset": 107,
-        "length": 57,
-        "offset": 100,
-        "parent": {
-          "children": [
-            [Circular],
-          ],
-          "length": 75,
-          "offset": 90,
-          "parent": {
-            "children": [
-              {
-                "length": 7,
-                "offset": 81,
-                "parent": [Circular],
-                "type": "string",
-                "value": "label",
-              },
-              [Circular],
-            ],
-            "colonOffset": 88,
-            "length": 84,
-            "offset": 81,
-            "parent": {
-              "children": [
-                {
-                  "children": [
-                    {
-                      "length": 4,
-                      "offset": 13,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "id",
-                    },
-                    {
-                      "length": 1,
-                      "offset": 19,
-                      "parent": [Circular],
-                      "type": "number",
-                      "value": 1,
-                    },
-                  ],
-                  "colonOffset": 17,
-                  "length": 7,
-                  "offset": 13,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                {
-                  "children": [
-                    {
-                      "length": 6,
-                      "offset": 28,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "type",
-                    },
-                    {
-                      "length": 7,
-                      "offset": 36,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "input",
-                    },
-                  ],
-                  "colonOffset": 34,
-                  "length": 15,
-                  "offset": 28,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                {
-                  "children": [
-                    {
-                      "length": 9,
-                      "offset": 51,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "binding",
-                    },
-                    {
-                      "length": 11,
-                      "offset": 62,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "some.data",
-                    },
-                  ],
-                  "colonOffset": 60,
-                  "length": 22,
-                  "offset": 51,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                [Circular],
-              ],
-              "length": 165,
-              "offset": 5,
-              "type": "object",
-            },
-            "type": "property",
-          },
-          "type": "object",
-        },
-        "type": "property",
-      },
-      "type": "object",
-    },
-    "type": "missing",
-  },
-  {
-    "message": "Property "type" missing from type "Asset"",
-    "node": {
-      "children": [
-        {
-          "children": [
-            {
-              "length": 7,
-              "offset": 121,
-              "parent": [Circular],
-              "type": "string",
-              "value": "value",
-            },
-            {
-              "length": 17,
-              "offset": 130,
-              "parent": [Circular],
-              "type": "string",
-              "value": "{{input.label}}",
-            },
-          ],
-          "colonOffset": 128,
-          "length": 26,
-          "offset": 121,
-          "parent": [Circular],
-          "type": "property",
-        },
-      ],
-      "length": 48,
-      "offset": 109,
-      "parent": {
-        "children": [
-          {
-            "length": 7,
-            "offset": 100,
-            "parent": [Circular],
-            "type": "string",
-            "value": "asset",
-          },
-          [Circular],
-        ],
-        "colonOffset": 107,
-        "length": 57,
-        "offset": 100,
-        "parent": {
-          "children": [
-            [Circular],
-          ],
-          "length": 75,
-          "offset": 90,
-          "parent": {
-            "children": [
-              {
-                "length": 7,
-                "offset": 81,
-                "parent": [Circular],
-                "type": "string",
-                "value": "label",
-              },
-              [Circular],
-            ],
-            "colonOffset": 88,
-            "length": 84,
-            "offset": 81,
-            "parent": {
-              "children": [
-                {
-                  "children": [
-                    {
-                      "length": 4,
-                      "offset": 13,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "id",
-                    },
-                    {
-                      "length": 1,
-                      "offset": 19,
-                      "parent": [Circular],
-                      "type": "number",
-                      "value": 1,
-                    },
-                  ],
-                  "colonOffset": 17,
-                  "length": 7,
-                  "offset": 13,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                {
-                  "children": [
-                    {
-                      "length": 6,
-                      "offset": 28,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "type",
-                    },
-                    {
-                      "length": 7,
-                      "offset": 36,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "input",
-                    },
-                  ],
-                  "colonOffset": 34,
-                  "length": 15,
-                  "offset": 28,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                {
-                  "children": [
-                    {
-                      "length": 9,
-                      "offset": 51,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "binding",
-                    },
-                    {
-                      "length": 11,
-                      "offset": 62,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "some.data",
-                    },
-                  ],
-                  "colonOffset": 60,
-                  "length": 22,
-                  "offset": 51,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                [Circular],
-              ],
-              "length": 165,
-              "offset": 5,
-              "type": "object",
-            },
-            "type": "property",
-          },
-          "type": "object",
-        },
-        "type": "property",
-      },
-      "type": "object",
-    },
-    "type": "missing",
-  },
-]
-`;
-
-exports[`Basic Validation > Basic Validation By Type 1`] = `
-[
-  {
-    "message": "Expected type "string" but got "number"",
-    "node": {
-      "children": [
-        {
-          "length": 4,
-          "offset": 13,
-          "parent": [Circular],
-          "type": "string",
-          "value": "id",
-        },
-        {
-          "length": 1,
-          "offset": 19,
-          "parent": [Circular],
-          "type": "number",
-          "value": 1,
-        },
-      ],
-      "colonOffset": 17,
-      "length": 7,
-      "offset": 13,
-      "parent": {
-        "children": [
-          [Circular],
-          {
-            "children": [
-              {
-                "length": 6,
-                "offset": 28,
-                "parent": [Circular],
-                "type": "string",
-                "value": "type",
-              },
-              {
-                "length": 7,
-                "offset": 36,
-                "parent": [Circular],
-                "type": "string",
-                "value": "input",
-              },
-            ],
-            "colonOffset": 34,
-            "length": 15,
-            "offset": 28,
-            "parent": [Circular],
-            "type": "property",
-          },
-          {
-            "children": [
-              {
-                "length": 9,
-                "offset": 51,
-                "parent": [Circular],
-                "type": "string",
-                "value": "binding",
-              },
-              {
-                "length": 11,
-                "offset": 62,
-                "parent": [Circular],
-                "type": "string",
-                "value": "some.data",
-              },
-            ],
-            "colonOffset": 60,
-            "length": 22,
-            "offset": 51,
-            "parent": [Circular],
-            "type": "property",
-          },
-          {
-            "children": [
-              {
-                "length": 7,
-                "offset": 81,
-                "parent": [Circular],
-                "type": "string",
-                "value": "label",
-              },
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "length": 7,
-                        "offset": 100,
-                        "parent": [Circular],
-                        "type": "string",
-                        "value": "asset",
-                      },
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "length": 7,
-                                "offset": 121,
-                                "parent": [Circular],
-                                "type": "string",
-                                "value": "value",
-                              },
-                              {
-                                "length": 17,
-                                "offset": 130,
-                                "parent": [Circular],
-                                "type": "string",
-                                "value": "{{input.label}}",
-                              },
-                            ],
-                            "colonOffset": 128,
-                            "length": 26,
-                            "offset": 121,
-                            "parent": [Circular],
-                            "type": "property",
-                          },
-                        ],
-                        "length": 48,
-                        "offset": 109,
-                        "parent": [Circular],
-                        "type": "object",
-                      },
-                    ],
-                    "colonOffset": 107,
-                    "length": 57,
-                    "offset": 100,
-                    "parent": [Circular],
-                    "type": "property",
-                  },
-                ],
-                "length": 75,
-                "offset": 90,
-                "parent": [Circular],
-                "type": "object",
-              },
-            ],
-            "colonOffset": 88,
-            "length": 84,
-            "offset": 81,
-            "parent": [Circular],
-            "type": "property",
-          },
-        ],
-        "length": 165,
-        "offset": 5,
-        "type": "object",
-      },
-      "type": "property",
-    },
-    "type": "type",
-  },
-  {
-    "message": "Property "id" missing from type "Asset"",
-    "node": {
-      "children": [
-        {
-          "children": [
-            {
-              "length": 7,
-              "offset": 121,
-              "parent": [Circular],
-              "type": "string",
-              "value": "value",
-            },
-            {
-              "length": 17,
-              "offset": 130,
-              "parent": [Circular],
-              "type": "string",
-              "value": "{{input.label}}",
-            },
-          ],
-          "colonOffset": 128,
-          "length": 26,
-          "offset": 121,
-          "parent": [Circular],
-          "type": "property",
-        },
-      ],
-      "length": 48,
-      "offset": 109,
-      "parent": {
-        "children": [
-          {
-            "length": 7,
-            "offset": 100,
-            "parent": [Circular],
-            "type": "string",
-            "value": "asset",
-          },
-          [Circular],
-        ],
-        "colonOffset": 107,
-        "length": 57,
-        "offset": 100,
-        "parent": {
-          "children": [
-            [Circular],
-          ],
-          "length": 75,
-          "offset": 90,
-          "parent": {
-            "children": [
-              {
-                "length": 7,
-                "offset": 81,
-                "parent": [Circular],
-                "type": "string",
-                "value": "label",
-              },
-              [Circular],
-            ],
-            "colonOffset": 88,
-            "length": 84,
-            "offset": 81,
-            "parent": {
-              "children": [
-                {
-                  "children": [
-                    {
-                      "length": 4,
-                      "offset": 13,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "id",
-                    },
-                    {
-                      "length": 1,
-                      "offset": 19,
-                      "parent": [Circular],
-                      "type": "number",
-                      "value": 1,
-                    },
-                  ],
-                  "colonOffset": 17,
-                  "length": 7,
-                  "offset": 13,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                {
-                  "children": [
-                    {
-                      "length": 6,
-                      "offset": 28,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "type",
-                    },
-                    {
-                      "length": 7,
-                      "offset": 36,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "input",
-                    },
-                  ],
-                  "colonOffset": 34,
-                  "length": 15,
-                  "offset": 28,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                {
-                  "children": [
-                    {
-                      "length": 9,
-                      "offset": 51,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "binding",
-                    },
-                    {
-                      "length": 11,
-                      "offset": 62,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "some.data",
-                    },
-                  ],
-                  "colonOffset": 60,
-                  "length": 22,
-                  "offset": 51,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                [Circular],
-              ],
-              "length": 165,
-              "offset": 5,
-              "type": "object",
-            },
-            "type": "property",
-          },
-          "type": "object",
-        },
-        "type": "property",
-      },
-      "type": "object",
-    },
-    "type": "missing",
-  },
-  {
-    "message": "Property "type" missing from type "Asset"",
-    "node": {
-      "children": [
-        {
-          "children": [
-            {
-              "length": 7,
-              "offset": 121,
-              "parent": [Circular],
-              "type": "string",
-              "value": "value",
-            },
-            {
-              "length": 17,
-              "offset": 130,
-              "parent": [Circular],
-              "type": "string",
-              "value": "{{input.label}}",
-            },
-          ],
-          "colonOffset": 128,
-          "length": 26,
-          "offset": 121,
-          "parent": [Circular],
-          "type": "property",
-        },
-      ],
-      "length": 48,
-      "offset": 109,
-      "parent": {
-        "children": [
-          {
-            "length": 7,
-            "offset": 100,
-            "parent": [Circular],
-            "type": "string",
-            "value": "asset",
-          },
-          [Circular],
-        ],
-        "colonOffset": 107,
-        "length": 57,
-        "offset": 100,
-        "parent": {
-          "children": [
-            [Circular],
-          ],
-          "length": 75,
-          "offset": 90,
-          "parent": {
-            "children": [
-              {
-                "length": 7,
-                "offset": 81,
-                "parent": [Circular],
-                "type": "string",
-                "value": "label",
-              },
-              [Circular],
-            ],
-            "colonOffset": 88,
-            "length": 84,
-            "offset": 81,
-            "parent": {
-              "children": [
-                {
-                  "children": [
-                    {
-                      "length": 4,
-                      "offset": 13,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "id",
-                    },
-                    {
-                      "length": 1,
-                      "offset": 19,
-                      "parent": [Circular],
-                      "type": "number",
-                      "value": 1,
-                    },
-                  ],
-                  "colonOffset": 17,
-                  "length": 7,
-                  "offset": 13,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                {
-                  "children": [
-                    {
-                      "length": 6,
-                      "offset": 28,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "type",
-                    },
-                    {
-                      "length": 7,
-                      "offset": 36,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "input",
-                    },
-                  ],
-                  "colonOffset": 34,
-                  "length": 15,
-                  "offset": 28,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                {
-                  "children": [
-                    {
-                      "length": 9,
-                      "offset": 51,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "binding",
-                    },
-                    {
-                      "length": 11,
-                      "offset": 62,
-                      "parent": [Circular],
-                      "type": "string",
-                      "value": "some.data",
-                    },
-                  ],
-                  "colonOffset": 60,
-                  "length": 22,
-                  "offset": 51,
-                  "parent": [Circular],
-                  "type": "property",
-                },
-                [Circular],
-              ],
-              "length": 165,
-              "offset": 5,
-              "type": "object",
-            },
-            "type": "property",
-          },
-          "type": "object",
-        },
-        "type": "property",
-      },
-      "type": "object",
-    },
-    "type": "missing",
-  },
-]
-`;
-
 exports[`Export Test > Exports Typescript Types With Filters 1`] = `
 "import { Expression, Asset, Binding, AssetWrapper } from "@player-ui/types";
 
@@ -2172,7 +1256,7 @@ export interface CollectionAsset extends Asset<'collection'> {
 }"
 `;
 
-exports[`Object Recall > Processed 1`] = `
+exports[`Object Recall > Optimized 1`] = `
 {
   "additionalProperties": {
     "type": "unknown",
@@ -2458,6 +1542,130 @@ Players can get field type information from the 'schema' definition, thus to dec
 }
 `;
 
+exports[`Object Recall > Processed 1`] = `
+{
+  "additionalProperties": {
+    "type": "unknown",
+  },
+  "description": "This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
+Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.",
+  "extends": undefined,
+  "genericTokens": [
+    {
+      "constraints": {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "default": {
+        "ref": "Asset",
+        "type": "ref",
+      },
+      "symbol": "AnyTextAsset",
+    },
+  ],
+  "name": "InputAsset",
+  "properties": {
+    "binding": {
+      "node": {
+        "description": "The location in the data-model to store the data",
+        "ref": "Binding",
+        "title": "InputAsset.binding",
+        "type": "ref",
+      },
+      "required": true,
+    },
+    "id": {
+      "node": {
+        "description": "Each asset requires a unique id per view",
+        "title": "Asset.id",
+        "type": "string",
+      },
+      "required": true,
+    },
+    "label": {
+      "node": {
+        "description": "Asset container for a field label.",
+        "genericArguments": [
+          {
+            "ref": "Asset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyTextAsset>",
+        "title": "InputAsset.label",
+        "type": "ref",
+      },
+      "required": false,
+    },
+    "metaData": {
+      "node": {
+        "additionalProperties": false,
+        "description": "Optional additional data",
+        "extends": undefined,
+        "properties": {
+          "beacon": {
+            "node": {
+              "description": "Additional data to beacon when this input changes",
+              "name": "BeaconDataType",
+              "or": [
+                {
+                  "title": "BeaconDataType",
+                  "type": "string",
+                },
+                {
+                  "keyType": {
+                    "type": "string",
+                  },
+                  "title": "BeaconDataType",
+                  "type": "record",
+                  "valueType": {
+                    "type": "any",
+                  },
+                },
+              ],
+              "source": "/private/var/tmp/_bazel_kreddy8/6fc13ccb395252816f0c23d8394e8532/sandbox/darwin-sandbox/134/execroot/player/node_modules/@player-ui/beacon-plugin/dist/index.d.ts",
+              "title": "InputAsset.metaData.beacon",
+              "type": "or",
+            },
+            "required": false,
+          },
+        },
+        "title": "InputAsset.metaData",
+        "type": "object",
+      },
+      "required": false,
+    },
+    "note": {
+      "node": {
+        "description": "Asset container for a note.",
+        "genericArguments": [
+          {
+            "ref": "Asset",
+            "type": "ref",
+          },
+        ],
+        "ref": "AssetWrapper<AnyTextAsset>",
+        "title": "InputAsset.note",
+        "type": "ref",
+      },
+      "required": false,
+    },
+    "type": {
+      "node": {
+        "const": "input",
+        "description": "The asset type determines the semantics of how a user interacts with a page",
+        "title": "Asset.type",
+        "type": "string",
+      },
+      "required": true,
+    },
+  },
+  "source": "src/index.ts",
+  "title": "Asset",
+  "type": "object",
+}
+`;
+
 exports[`Object Recall > Raw 1`] = `
 {
   "additionalProperties": false,
@@ -2569,4 +1777,1378 @@ Players can get field type information from the 'schema' definition, thus to dec
   "title": "InputAsset",
   "type": "object",
 }
+`;
+
+exports[`Validation > Basic Validation By Name 1`] = `
+[
+  {
+    "message": "Expected type "string" but got "number"",
+    "node": {
+      "children": [
+        {
+          "length": 4,
+          "offset": 13,
+          "parent": [Circular],
+          "type": "string",
+          "value": "id",
+        },
+        {
+          "length": 1,
+          "offset": 19,
+          "parent": [Circular],
+          "type": "number",
+          "value": 1,
+        },
+      ],
+      "colonOffset": 17,
+      "length": 7,
+      "offset": 13,
+      "parent": {
+        "children": [
+          [Circular],
+          {
+            "children": [
+              {
+                "length": 6,
+                "offset": 28,
+                "parent": [Circular],
+                "type": "string",
+                "value": "type",
+              },
+              {
+                "length": 7,
+                "offset": 36,
+                "parent": [Circular],
+                "type": "string",
+                "value": "input",
+              },
+            ],
+            "colonOffset": 34,
+            "length": 15,
+            "offset": 28,
+            "parent": [Circular],
+            "type": "property",
+          },
+          {
+            "children": [
+              {
+                "length": 9,
+                "offset": 51,
+                "parent": [Circular],
+                "type": "string",
+                "value": "binding",
+              },
+              {
+                "length": 11,
+                "offset": 62,
+                "parent": [Circular],
+                "type": "string",
+                "value": "some.data",
+              },
+            ],
+            "colonOffset": 60,
+            "length": 22,
+            "offset": 51,
+            "parent": [Circular],
+            "type": "property",
+          },
+          {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "length": 7,
+                        "offset": 100,
+                        "parent": [Circular],
+                        "type": "string",
+                        "value": "asset",
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "length": 7,
+                                "offset": 121,
+                                "parent": [Circular],
+                                "type": "string",
+                                "value": "value",
+                              },
+                              {
+                                "length": 17,
+                                "offset": 130,
+                                "parent": [Circular],
+                                "type": "string",
+                                "value": "{{input.label}}",
+                              },
+                            ],
+                            "colonOffset": 128,
+                            "length": 26,
+                            "offset": 121,
+                            "parent": [Circular],
+                            "type": "property",
+                          },
+                        ],
+                        "length": 48,
+                        "offset": 109,
+                        "parent": [Circular],
+                        "type": "object",
+                      },
+                    ],
+                    "colonOffset": 107,
+                    "length": 57,
+                    "offset": 100,
+                    "parent": [Circular],
+                    "type": "property",
+                  },
+                ],
+                "length": 75,
+                "offset": 90,
+                "parent": [Circular],
+                "type": "object",
+              },
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": [Circular],
+            "type": "property",
+          },
+        ],
+        "length": 165,
+        "offset": 5,
+        "type": "object",
+      },
+      "type": "property",
+    },
+    "type": "type",
+  },
+  {
+    "message": "Property "id" missing from type "Asset"",
+    "node": {
+      "children": [
+        {
+          "children": [
+            {
+              "length": 7,
+              "offset": 121,
+              "parent": [Circular],
+              "type": "string",
+              "value": "value",
+            },
+            {
+              "length": 17,
+              "offset": 130,
+              "parent": [Circular],
+              "type": "string",
+              "value": "{{input.label}}",
+            },
+          ],
+          "colonOffset": 128,
+          "length": 26,
+          "offset": 121,
+          "parent": [Circular],
+          "type": "property",
+        },
+      ],
+      "length": 48,
+      "offset": 109,
+      "parent": {
+        "children": [
+          {
+            "length": 7,
+            "offset": 100,
+            "parent": [Circular],
+            "type": "string",
+            "value": "asset",
+          },
+          [Circular],
+        ],
+        "colonOffset": 107,
+        "length": 57,
+        "offset": 100,
+        "parent": {
+          "children": [
+            [Circular],
+          ],
+          "length": 75,
+          "offset": 90,
+          "parent": {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              [Circular],
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "length": 4,
+                      "offset": 13,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "id",
+                    },
+                    {
+                      "length": 1,
+                      "offset": 19,
+                      "parent": [Circular],
+                      "type": "number",
+                      "value": 1,
+                    },
+                  ],
+                  "colonOffset": 17,
+                  "length": 7,
+                  "offset": 13,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 6,
+                      "offset": 28,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "type",
+                    },
+                    {
+                      "length": 7,
+                      "offset": 36,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "input",
+                    },
+                  ],
+                  "colonOffset": 34,
+                  "length": 15,
+                  "offset": 28,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 9,
+                      "offset": 51,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "binding",
+                    },
+                    {
+                      "length": 11,
+                      "offset": 62,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "some.data",
+                    },
+                  ],
+                  "colonOffset": 60,
+                  "length": 22,
+                  "offset": 51,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                [Circular],
+              ],
+              "length": 165,
+              "offset": 5,
+              "type": "object",
+            },
+            "type": "property",
+          },
+          "type": "object",
+        },
+        "type": "property",
+      },
+      "type": "object",
+    },
+    "type": "missing",
+  },
+  {
+    "message": "Property "type" missing from type "Asset"",
+    "node": {
+      "children": [
+        {
+          "children": [
+            {
+              "length": 7,
+              "offset": 121,
+              "parent": [Circular],
+              "type": "string",
+              "value": "value",
+            },
+            {
+              "length": 17,
+              "offset": 130,
+              "parent": [Circular],
+              "type": "string",
+              "value": "{{input.label}}",
+            },
+          ],
+          "colonOffset": 128,
+          "length": 26,
+          "offset": 121,
+          "parent": [Circular],
+          "type": "property",
+        },
+      ],
+      "length": 48,
+      "offset": 109,
+      "parent": {
+        "children": [
+          {
+            "length": 7,
+            "offset": 100,
+            "parent": [Circular],
+            "type": "string",
+            "value": "asset",
+          },
+          [Circular],
+        ],
+        "colonOffset": 107,
+        "length": 57,
+        "offset": 100,
+        "parent": {
+          "children": [
+            [Circular],
+          ],
+          "length": 75,
+          "offset": 90,
+          "parent": {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              [Circular],
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "length": 4,
+                      "offset": 13,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "id",
+                    },
+                    {
+                      "length": 1,
+                      "offset": 19,
+                      "parent": [Circular],
+                      "type": "number",
+                      "value": 1,
+                    },
+                  ],
+                  "colonOffset": 17,
+                  "length": 7,
+                  "offset": 13,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 6,
+                      "offset": 28,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "type",
+                    },
+                    {
+                      "length": 7,
+                      "offset": 36,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "input",
+                    },
+                  ],
+                  "colonOffset": 34,
+                  "length": 15,
+                  "offset": 28,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 9,
+                      "offset": 51,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "binding",
+                    },
+                    {
+                      "length": 11,
+                      "offset": 62,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "some.data",
+                    },
+                  ],
+                  "colonOffset": 60,
+                  "length": 22,
+                  "offset": 51,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                [Circular],
+              ],
+              "length": 165,
+              "offset": 5,
+              "type": "object",
+            },
+            "type": "property",
+          },
+          "type": "object",
+        },
+        "type": "property",
+      },
+      "type": "object",
+    },
+    "type": "missing",
+  },
+]
+`;
+
+exports[`Validation > Basic Validation By Type (optimized) 1`] = `
+[
+  {
+    "message": "Expected type "string" but got "number"",
+    "node": {
+      "children": [
+        {
+          "length": 4,
+          "offset": 13,
+          "parent": [Circular],
+          "type": "string",
+          "value": "id",
+        },
+        {
+          "length": 1,
+          "offset": 19,
+          "parent": [Circular],
+          "type": "number",
+          "value": 1,
+        },
+      ],
+      "colonOffset": 17,
+      "length": 7,
+      "offset": 13,
+      "parent": {
+        "children": [
+          [Circular],
+          {
+            "children": [
+              {
+                "length": 6,
+                "offset": 28,
+                "parent": [Circular],
+                "type": "string",
+                "value": "type",
+              },
+              {
+                "length": 7,
+                "offset": 36,
+                "parent": [Circular],
+                "type": "string",
+                "value": "input",
+              },
+            ],
+            "colonOffset": 34,
+            "length": 15,
+            "offset": 28,
+            "parent": [Circular],
+            "type": "property",
+          },
+          {
+            "children": [
+              {
+                "length": 9,
+                "offset": 51,
+                "parent": [Circular],
+                "type": "string",
+                "value": "binding",
+              },
+              {
+                "length": 11,
+                "offset": 62,
+                "parent": [Circular],
+                "type": "string",
+                "value": "some.data",
+              },
+            ],
+            "colonOffset": 60,
+            "length": 22,
+            "offset": 51,
+            "parent": [Circular],
+            "type": "property",
+          },
+          {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "length": 7,
+                        "offset": 100,
+                        "parent": [Circular],
+                        "type": "string",
+                        "value": "asset",
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "length": 7,
+                                "offset": 121,
+                                "parent": [Circular],
+                                "type": "string",
+                                "value": "value",
+                              },
+                              {
+                                "length": 17,
+                                "offset": 130,
+                                "parent": [Circular],
+                                "type": "string",
+                                "value": "{{input.label}}",
+                              },
+                            ],
+                            "colonOffset": 128,
+                            "length": 26,
+                            "offset": 121,
+                            "parent": [Circular],
+                            "type": "property",
+                          },
+                        ],
+                        "length": 48,
+                        "offset": 109,
+                        "parent": [Circular],
+                        "type": "object",
+                      },
+                    ],
+                    "colonOffset": 107,
+                    "length": 57,
+                    "offset": 100,
+                    "parent": [Circular],
+                    "type": "property",
+                  },
+                ],
+                "length": 75,
+                "offset": 90,
+                "parent": [Circular],
+                "type": "object",
+              },
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": [Circular],
+            "type": "property",
+          },
+        ],
+        "length": 165,
+        "offset": 5,
+        "type": "object",
+      },
+      "type": "property",
+    },
+    "type": "type",
+  },
+  {
+    "message": "Property "id" missing from type "Asset"",
+    "node": {
+      "children": [
+        {
+          "children": [
+            {
+              "length": 7,
+              "offset": 121,
+              "parent": [Circular],
+              "type": "string",
+              "value": "value",
+            },
+            {
+              "length": 17,
+              "offset": 130,
+              "parent": [Circular],
+              "type": "string",
+              "value": "{{input.label}}",
+            },
+          ],
+          "colonOffset": 128,
+          "length": 26,
+          "offset": 121,
+          "parent": [Circular],
+          "type": "property",
+        },
+      ],
+      "length": 48,
+      "offset": 109,
+      "parent": {
+        "children": [
+          {
+            "length": 7,
+            "offset": 100,
+            "parent": [Circular],
+            "type": "string",
+            "value": "asset",
+          },
+          [Circular],
+        ],
+        "colonOffset": 107,
+        "length": 57,
+        "offset": 100,
+        "parent": {
+          "children": [
+            [Circular],
+          ],
+          "length": 75,
+          "offset": 90,
+          "parent": {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              [Circular],
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "length": 4,
+                      "offset": 13,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "id",
+                    },
+                    {
+                      "length": 1,
+                      "offset": 19,
+                      "parent": [Circular],
+                      "type": "number",
+                      "value": 1,
+                    },
+                  ],
+                  "colonOffset": 17,
+                  "length": 7,
+                  "offset": 13,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 6,
+                      "offset": 28,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "type",
+                    },
+                    {
+                      "length": 7,
+                      "offset": 36,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "input",
+                    },
+                  ],
+                  "colonOffset": 34,
+                  "length": 15,
+                  "offset": 28,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 9,
+                      "offset": 51,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "binding",
+                    },
+                    {
+                      "length": 11,
+                      "offset": 62,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "some.data",
+                    },
+                  ],
+                  "colonOffset": 60,
+                  "length": 22,
+                  "offset": 51,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                [Circular],
+              ],
+              "length": 165,
+              "offset": 5,
+              "type": "object",
+            },
+            "type": "property",
+          },
+          "type": "object",
+        },
+        "type": "property",
+      },
+      "type": "object",
+    },
+    "type": "missing",
+  },
+  {
+    "message": "Property "type" missing from type "Asset"",
+    "node": {
+      "children": [
+        {
+          "children": [
+            {
+              "length": 7,
+              "offset": 121,
+              "parent": [Circular],
+              "type": "string",
+              "value": "value",
+            },
+            {
+              "length": 17,
+              "offset": 130,
+              "parent": [Circular],
+              "type": "string",
+              "value": "{{input.label}}",
+            },
+          ],
+          "colonOffset": 128,
+          "length": 26,
+          "offset": 121,
+          "parent": [Circular],
+          "type": "property",
+        },
+      ],
+      "length": 48,
+      "offset": 109,
+      "parent": {
+        "children": [
+          {
+            "length": 7,
+            "offset": 100,
+            "parent": [Circular],
+            "type": "string",
+            "value": "asset",
+          },
+          [Circular],
+        ],
+        "colonOffset": 107,
+        "length": 57,
+        "offset": 100,
+        "parent": {
+          "children": [
+            [Circular],
+          ],
+          "length": 75,
+          "offset": 90,
+          "parent": {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              [Circular],
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "length": 4,
+                      "offset": 13,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "id",
+                    },
+                    {
+                      "length": 1,
+                      "offset": 19,
+                      "parent": [Circular],
+                      "type": "number",
+                      "value": 1,
+                    },
+                  ],
+                  "colonOffset": 17,
+                  "length": 7,
+                  "offset": 13,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 6,
+                      "offset": 28,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "type",
+                    },
+                    {
+                      "length": 7,
+                      "offset": 36,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "input",
+                    },
+                  ],
+                  "colonOffset": 34,
+                  "length": 15,
+                  "offset": 28,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 9,
+                      "offset": 51,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "binding",
+                    },
+                    {
+                      "length": 11,
+                      "offset": 62,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "some.data",
+                    },
+                  ],
+                  "colonOffset": 60,
+                  "length": 22,
+                  "offset": 51,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                [Circular],
+              ],
+              "length": 165,
+              "offset": 5,
+              "type": "object",
+            },
+            "type": "property",
+          },
+          "type": "object",
+        },
+        "type": "property",
+      },
+      "type": "object",
+    },
+    "type": "missing",
+  },
+]
+`;
+
+exports[`Validation > Basic Validation By Type (unoptimized) 1`] = `
+[
+  {
+    "message": "Expected type "string" but got "number"",
+    "node": {
+      "children": [
+        {
+          "length": 4,
+          "offset": 13,
+          "parent": [Circular],
+          "type": "string",
+          "value": "id",
+        },
+        {
+          "length": 1,
+          "offset": 19,
+          "parent": [Circular],
+          "type": "number",
+          "value": 1,
+        },
+      ],
+      "colonOffset": 17,
+      "length": 7,
+      "offset": 13,
+      "parent": {
+        "children": [
+          [Circular],
+          {
+            "children": [
+              {
+                "length": 6,
+                "offset": 28,
+                "parent": [Circular],
+                "type": "string",
+                "value": "type",
+              },
+              {
+                "length": 7,
+                "offset": 36,
+                "parent": [Circular],
+                "type": "string",
+                "value": "input",
+              },
+            ],
+            "colonOffset": 34,
+            "length": 15,
+            "offset": 28,
+            "parent": [Circular],
+            "type": "property",
+          },
+          {
+            "children": [
+              {
+                "length": 9,
+                "offset": 51,
+                "parent": [Circular],
+                "type": "string",
+                "value": "binding",
+              },
+              {
+                "length": 11,
+                "offset": 62,
+                "parent": [Circular],
+                "type": "string",
+                "value": "some.data",
+              },
+            ],
+            "colonOffset": 60,
+            "length": 22,
+            "offset": 51,
+            "parent": [Circular],
+            "type": "property",
+          },
+          {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "length": 7,
+                        "offset": 100,
+                        "parent": [Circular],
+                        "type": "string",
+                        "value": "asset",
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "length": 7,
+                                "offset": 121,
+                                "parent": [Circular],
+                                "type": "string",
+                                "value": "value",
+                              },
+                              {
+                                "length": 17,
+                                "offset": 130,
+                                "parent": [Circular],
+                                "type": "string",
+                                "value": "{{input.label}}",
+                              },
+                            ],
+                            "colonOffset": 128,
+                            "length": 26,
+                            "offset": 121,
+                            "parent": [Circular],
+                            "type": "property",
+                          },
+                        ],
+                        "length": 48,
+                        "offset": 109,
+                        "parent": [Circular],
+                        "type": "object",
+                      },
+                    ],
+                    "colonOffset": 107,
+                    "length": 57,
+                    "offset": 100,
+                    "parent": [Circular],
+                    "type": "property",
+                  },
+                ],
+                "length": 75,
+                "offset": 90,
+                "parent": [Circular],
+                "type": "object",
+              },
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": [Circular],
+            "type": "property",
+          },
+        ],
+        "length": 165,
+        "offset": 5,
+        "type": "object",
+      },
+      "type": "property",
+    },
+    "type": "type",
+  },
+  {
+    "message": "Property "id" missing from type "Asset"",
+    "node": {
+      "children": [
+        {
+          "children": [
+            {
+              "length": 7,
+              "offset": 121,
+              "parent": [Circular],
+              "type": "string",
+              "value": "value",
+            },
+            {
+              "length": 17,
+              "offset": 130,
+              "parent": [Circular],
+              "type": "string",
+              "value": "{{input.label}}",
+            },
+          ],
+          "colonOffset": 128,
+          "length": 26,
+          "offset": 121,
+          "parent": [Circular],
+          "type": "property",
+        },
+      ],
+      "length": 48,
+      "offset": 109,
+      "parent": {
+        "children": [
+          {
+            "length": 7,
+            "offset": 100,
+            "parent": [Circular],
+            "type": "string",
+            "value": "asset",
+          },
+          [Circular],
+        ],
+        "colonOffset": 107,
+        "length": 57,
+        "offset": 100,
+        "parent": {
+          "children": [
+            [Circular],
+          ],
+          "length": 75,
+          "offset": 90,
+          "parent": {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              [Circular],
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "length": 4,
+                      "offset": 13,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "id",
+                    },
+                    {
+                      "length": 1,
+                      "offset": 19,
+                      "parent": [Circular],
+                      "type": "number",
+                      "value": 1,
+                    },
+                  ],
+                  "colonOffset": 17,
+                  "length": 7,
+                  "offset": 13,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 6,
+                      "offset": 28,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "type",
+                    },
+                    {
+                      "length": 7,
+                      "offset": 36,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "input",
+                    },
+                  ],
+                  "colonOffset": 34,
+                  "length": 15,
+                  "offset": 28,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 9,
+                      "offset": 51,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "binding",
+                    },
+                    {
+                      "length": 11,
+                      "offset": 62,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "some.data",
+                    },
+                  ],
+                  "colonOffset": 60,
+                  "length": 22,
+                  "offset": 51,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                [Circular],
+              ],
+              "length": 165,
+              "offset": 5,
+              "type": "object",
+            },
+            "type": "property",
+          },
+          "type": "object",
+        },
+        "type": "property",
+      },
+      "type": "object",
+    },
+    "type": "missing",
+  },
+  {
+    "message": "Property "type" missing from type "Asset"",
+    "node": {
+      "children": [
+        {
+          "children": [
+            {
+              "length": 7,
+              "offset": 121,
+              "parent": [Circular],
+              "type": "string",
+              "value": "value",
+            },
+            {
+              "length": 17,
+              "offset": 130,
+              "parent": [Circular],
+              "type": "string",
+              "value": "{{input.label}}",
+            },
+          ],
+          "colonOffset": 128,
+          "length": 26,
+          "offset": 121,
+          "parent": [Circular],
+          "type": "property",
+        },
+      ],
+      "length": 48,
+      "offset": 109,
+      "parent": {
+        "children": [
+          {
+            "length": 7,
+            "offset": 100,
+            "parent": [Circular],
+            "type": "string",
+            "value": "asset",
+          },
+          [Circular],
+        ],
+        "colonOffset": 107,
+        "length": 57,
+        "offset": 100,
+        "parent": {
+          "children": [
+            [Circular],
+          ],
+          "length": 75,
+          "offset": 90,
+          "parent": {
+            "children": [
+              {
+                "length": 7,
+                "offset": 81,
+                "parent": [Circular],
+                "type": "string",
+                "value": "label",
+              },
+              [Circular],
+            ],
+            "colonOffset": 88,
+            "length": 84,
+            "offset": 81,
+            "parent": {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "length": 4,
+                      "offset": 13,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "id",
+                    },
+                    {
+                      "length": 1,
+                      "offset": 19,
+                      "parent": [Circular],
+                      "type": "number",
+                      "value": 1,
+                    },
+                  ],
+                  "colonOffset": 17,
+                  "length": 7,
+                  "offset": 13,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 6,
+                      "offset": 28,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "type",
+                    },
+                    {
+                      "length": 7,
+                      "offset": 36,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "input",
+                    },
+                  ],
+                  "colonOffset": 34,
+                  "length": 15,
+                  "offset": 28,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                {
+                  "children": [
+                    {
+                      "length": 9,
+                      "offset": 51,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "binding",
+                    },
+                    {
+                      "length": 11,
+                      "offset": 62,
+                      "parent": [Circular],
+                      "type": "string",
+                      "value": "some.data",
+                    },
+                  ],
+                  "colonOffset": 60,
+                  "length": 22,
+                  "offset": 51,
+                  "parent": [Circular],
+                  "type": "property",
+                },
+                [Circular],
+              ],
+              "length": 165,
+              "offset": 5,
+              "type": "object",
+            },
+            "type": "property",
+          },
+          "type": "object",
+        },
+        "type": "property",
+      },
+      "type": "object",
+    },
+    "type": "missing",
+  },
+]
 `;

--- a/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
+++ b/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
@@ -1353,10 +1353,11 @@ Players can get field type information from the 'schema' definition, thus to dec
   "properties": {
     "binding": {
       "node": {
-        "description": "The location in the data-model to store the data",
-        "ref": "Binding",
-        "title": "InputAsset.binding",
-        "type": "ref",
+        "description": "Bindings describe locations in the data model.",
+        "name": "Binding",
+        "source": "src/index.ts",
+        "title": "Binding",
+        "type": "string",
       },
       "required": true,
     },

--- a/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
+++ b/xlr/sdk/src/__tests__/__snapshots__/sdk.test.ts.snap
@@ -923,11 +923,7 @@ exports[`Export Test > Exports Typescript Types With Filters 1`] = `
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'input';
+export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
     /** Asset container for a note. */
@@ -939,13 +935,8 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> {
         /** Additional data to beacon when this input changes */
         beacon?: string | Record<string, any>;
     };
-    [key: string]: unknown;
 }
-export interface TextAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'text';
+export interface TextAsset extends Asset<'text'> {
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -968,18 +959,13 @@ export interface TextAsset {
             'mime-type'?: string;
         };
     }>;
-    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'action';
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -995,13 +981,8 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
         /** Force transition to the next view without checking for validation */
         skipValidation?: boolean;
     };
-    [key: string]: unknown;
 }
-export interface InfoAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'info';
+export interface InfoAsset extends Asset<'info'> {
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -1010,18 +991,12 @@ export interface InfoAsset {
     primaryInfo?: AssetWrapper;
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
-    [key: string]: unknown;
 }
-export interface CollectionAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'collection';
+export interface CollectionAsset extends Asset<'collection'> {
     /** An optional label to title the collection */
     label?: AssetWrapper;
     /** The string value to show */
     values?: Array<AssetWrapper>;
-    [key: string]: unknown;
 }"
 `;
 
@@ -1032,11 +1007,7 @@ exports[`Export Test > Exports Typescript Types With Transforms 1`] = `
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'input';
+export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
     /** Asset container for a note. */
@@ -1049,13 +1020,8 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> {
         beacon?: string | Record<string, any>;
     };
     transformed?: true;
-    [key: string]: unknown;
 }
-export interface TextAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'text';
+export interface TextAsset extends Asset<'text'> {
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -1079,18 +1045,13 @@ export interface TextAsset {
         };
     }>;
     transformed?: true;
-    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'action';
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -1107,13 +1068,8 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
         skipValidation?: boolean;
     };
     transformed?: true;
-    [key: string]: unknown;
 }
-export interface InfoAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'info';
+export interface InfoAsset extends Asset<'info'> {
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -1123,19 +1079,13 @@ export interface InfoAsset {
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
     transformed?: true;
-    [key: string]: unknown;
 }
-export interface CollectionAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'collection';
+export interface CollectionAsset extends Asset<'collection'> {
     /** An optional label to title the collection */
     label?: AssetWrapper;
     /** The string value to show */
     values?: Array<AssetWrapper>;
     transformed?: true;
-    [key: string]: unknown;
 }"
 `;
 
@@ -1151,14 +1101,9 @@ export interface Asset<T extends string = string> {
     [key: string]: unknown;
 }
 /** An asset that contains a Binding. */
-export interface AssetBinding<T extends string = string> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: T;
+export interface AssetBinding extends Asset {
     /** A binding that points to somewhere in the data model */
     binding: Binding;
-    [key: string]: unknown;
 }
 /** A single case statement to use in a switch */
 export interface SwitchCase<T extends Asset = Asset> {
@@ -1539,7 +1484,7 @@ export interface NavigationBaseState<T extends string = any> {
      * TS gets really confused with both the ActionState and the onStart state both declaring the \`exp\` property
      * So this explicity says there should never be an exp prop on a state node that's not of type 'ACTION'
     */
-    exp?: T extends T ? Expression : never;
+    exp?: T extends 'ACTION' ? Expression : never;
 }
 /** A generic state that can transition to another state */
 export interface NavigationFlowTransitionableState<T extends string = any> {
@@ -1561,7 +1506,7 @@ export interface NavigationFlowTransitionableState<T extends string = any> {
      * TS gets really confused with both the ActionState and the onStart state both declaring the \`exp\` property
      * So this explicity says there should never be an exp prop on a state node that's not of type 'ACTION'
     */
-    exp?: T extends T ? Expression : never;
+    exp?: T extends 'ACTION' ? Expression : never;
     /** A mapping of transition-name to FlowState name */
     transitions: Record<string, string>;
 }
@@ -1857,7 +1802,7 @@ export interface Template<ValueType extends any = unknown, Key extends string = 
     */
     output: Key;
 }
-export type View<T extends Asset = Asset> = unknown extends unknown ? T & {
+export type View<T extends Asset = Asset> = unknown extends Asset ? T & {
     /** Each view can optionally supply a list of validations to run against a particular view */
     validation?: Array<{
         /**
@@ -1885,7 +1830,7 @@ export interface Flow<T extends Asset = Asset> {
     /** A unique identifier for the flow */
     id: string;
     /** A list of views (each with an ID) that can be shown to a user */
-    views?: Array<unknown extends unknown ? T & {
+    views?: Array<unknown extends Asset ? T & {
         /** Each view can optionally supply a list of validations to run against a particular view */
         validation?: Array<{
             /**
@@ -2150,11 +2095,7 @@ export interface Flow<T extends Asset = Asset> {
  * This is the most generic way of gathering data. The input is bound to a data model using the 'binding' property.
  * Players can get field type information from the 'schema' definition, thus to decide the input controls for visual rendering.
 */
-export interface InputAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'input';
+export interface InputAsset<AnyTextAsset extends Asset = Asset> extends Asset<'input'> {
     /** Asset container for a field label. */
     label?: AssetWrapper<AnyTextAsset>;
     /** Asset container for a note. */
@@ -2166,13 +2107,8 @@ export interface InputAsset<AnyTextAsset extends Asset = Asset> {
         /** Additional data to beacon when this input changes */
         beacon?: string | Record<string, any>;
     };
-    [key: string]: unknown;
 }
-export interface TextAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'text';
+export interface TextAsset extends Asset<'text'> {
     /** The text to display */
     value: string;
     /** Any modifiers on the text */
@@ -2195,18 +2131,13 @@ export interface TextAsset {
             'mime-type'?: string;
         };
     }>;
-    [key: string]: unknown;
 }
 /**
  * User actions can be represented in several places.
  * Each view typically has one or more actions that allow the user to navigate away from that view.
  * In addition, several asset types can have actions that apply to that asset only.
 */
-export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'action';
+export interface ActionAsset<AnyTextAsset extends Asset = Asset> extends Asset<'action'> {
     /** The transition value of the action in the state machine */
     value?: string;
     /** A text-like asset for the action's label */
@@ -2222,13 +2153,8 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset> {
         /** Force transition to the next view without checking for validation */
         skipValidation?: boolean;
     };
-    [key: string]: unknown;
 }
-export interface InfoAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'info';
+export interface InfoAsset extends Asset<'info'> {
     /** The string value to show */
     title?: AssetWrapper;
     /** subtitle */
@@ -2237,18 +2163,12 @@ export interface InfoAsset {
     primaryInfo?: AssetWrapper;
     /** List of actions to show at the bottom of the page */
     actions?: Array<AssetWrapper>;
-    [key: string]: unknown;
 }
-export interface CollectionAsset {
-    /** Each asset requires a unique id per view */
-    id: string;
-    /** The asset type determines the semantics of how a user interacts with a page */
-    type: 'collection';
+export interface CollectionAsset extends Asset<'collection'> {
     /** An optional label to title the collection */
     label?: AssetWrapper;
     /** The string value to show */
     values?: Array<AssetWrapper>;
-    [key: string]: unknown;
 }"
 `;
 
@@ -2263,12 +2183,84 @@ Players can get field type information from the 'schema' definition, thus to dec
   "genericTokens": [
     {
       "constraints": {
-        "ref": "Asset",
-        "type": "ref",
+        "additionalProperties": {
+          "type": "unknown",
+        },
+        "description": "An asset is the smallest unit of user interaction in a player view",
+        "extends": undefined,
+        "genericTokens": [
+          {
+            "constraints": {
+              "type": "string",
+            },
+            "default": {
+              "type": "string",
+            },
+            "symbol": "T",
+          },
+        ],
+        "name": "Asset",
+        "properties": {
+          "id": {
+            "node": {
+              "description": "Each asset requires a unique id per view",
+              "title": "Asset.id",
+              "type": "string",
+            },
+            "required": true,
+          },
+          "type": {
+            "node": {
+              "description": "The asset type determines the semantics of how a user interacts with a page",
+              "title": "Asset.type",
+              "type": "string",
+            },
+            "required": true,
+          },
+        },
+        "source": "src/index.ts",
+        "title": "Asset",
+        "type": "object",
       },
       "default": {
-        "ref": "Asset",
-        "type": "ref",
+        "additionalProperties": {
+          "type": "unknown",
+        },
+        "description": "An asset is the smallest unit of user interaction in a player view",
+        "extends": undefined,
+        "genericTokens": [
+          {
+            "constraints": {
+              "type": "string",
+            },
+            "default": {
+              "type": "string",
+            },
+            "symbol": "T",
+          },
+        ],
+        "name": "Asset",
+        "properties": {
+          "id": {
+            "node": {
+              "description": "Each asset requires a unique id per view",
+              "title": "Asset.id",
+              "type": "string",
+            },
+            "required": true,
+          },
+          "type": {
+            "node": {
+              "description": "The asset type determines the semantics of how a user interacts with a page",
+              "title": "Asset.type",
+              "type": "string",
+            },
+            "required": true,
+          },
+        },
+        "source": "src/index.ts",
+        "title": "Asset",
+        "type": "object",
       },
       "symbol": "AnyTextAsset",
     },
@@ -2294,16 +2286,61 @@ Players can get field type information from the 'schema' definition, thus to dec
     },
     "label": {
       "node": {
-        "description": "Asset container for a field label.",
-        "genericArguments": [
-          {
-            "ref": "Asset",
-            "type": "ref",
+        "additionalProperties": {
+          "type": "unknown",
+        },
+        "description": "An object that contains an asset",
+        "extends": undefined,
+        "genericTokens": [],
+        "name": "AssetWrapper",
+        "properties": {
+          "asset": {
+            "node": {
+              "additionalProperties": {
+                "type": "unknown",
+              },
+              "description": "An asset is the smallest unit of user interaction in a player view",
+              "extends": undefined,
+              "genericTokens": [
+                {
+                  "constraints": {
+                    "type": "string",
+                  },
+                  "default": {
+                    "type": "string",
+                  },
+                  "symbol": "T",
+                },
+              ],
+              "name": "Asset",
+              "properties": {
+                "id": {
+                  "node": {
+                    "description": "Each asset requires a unique id per view",
+                    "title": "Asset.id",
+                    "type": "string",
+                  },
+                  "required": true,
+                },
+                "type": {
+                  "node": {
+                    "description": "The asset type determines the semantics of how a user interacts with a page",
+                    "title": "Asset.type",
+                    "type": "string",
+                  },
+                  "required": true,
+                },
+              },
+              "source": "src/index.ts",
+              "title": "Asset",
+              "type": "object",
+            },
+            "required": true,
           },
-        ],
-        "ref": "AssetWrapper<AnyTextAsset>",
-        "title": "InputAsset.label",
-        "type": "ref",
+        },
+        "source": "src/index.ts",
+        "title": "AssetWrapper",
+        "type": "object",
       },
       "required": false,
     },
@@ -2347,16 +2384,61 @@ Players can get field type information from the 'schema' definition, thus to dec
     },
     "note": {
       "node": {
-        "description": "Asset container for a note.",
-        "genericArguments": [
-          {
-            "ref": "Asset",
-            "type": "ref",
+        "additionalProperties": {
+          "type": "unknown",
+        },
+        "description": "An object that contains an asset",
+        "extends": undefined,
+        "genericTokens": [],
+        "name": "AssetWrapper",
+        "properties": {
+          "asset": {
+            "node": {
+              "additionalProperties": {
+                "type": "unknown",
+              },
+              "description": "An asset is the smallest unit of user interaction in a player view",
+              "extends": undefined,
+              "genericTokens": [
+                {
+                  "constraints": {
+                    "type": "string",
+                  },
+                  "default": {
+                    "type": "string",
+                  },
+                  "symbol": "T",
+                },
+              ],
+              "name": "Asset",
+              "properties": {
+                "id": {
+                  "node": {
+                    "description": "Each asset requires a unique id per view",
+                    "title": "Asset.id",
+                    "type": "string",
+                  },
+                  "required": true,
+                },
+                "type": {
+                  "node": {
+                    "description": "The asset type determines the semantics of how a user interacts with a page",
+                    "title": "Asset.type",
+                    "type": "string",
+                  },
+                  "required": true,
+                },
+              },
+              "source": "src/index.ts",
+              "title": "Asset",
+              "type": "object",
+            },
+            "required": true,
           },
-        ],
-        "ref": "AssetWrapper<AnyTextAsset>",
-        "title": "InputAsset.note",
-        "type": "ref",
+        },
+        "source": "src/index.ts",
+        "title": "AssetWrapper",
+        "type": "object",
       },
       "required": false,
     },

--- a/xlr/sdk/src/__tests__/sdk.test.ts
+++ b/xlr/sdk/src/__tests__/sdk.test.ts
@@ -48,14 +48,6 @@ describe("Loading XLRs", () => {
 });
 
 describe("Object Recall", () => {
-  test("Processed", () => {
-    const sdk = new XLRSDK();
-    sdk.loadDefinitionsFromModule(Types);
-    sdk.loadDefinitionsFromModule(ReferenceAssetsWebPluginManifest);
-
-    expect(sdk.getType("InputAsset")).toMatchSnapshot();
-  });
-
   test("Raw", () => {
     const sdk = new XLRSDK();
     sdk.loadDefinitionsFromModule(Types);
@@ -63,9 +55,25 @@ describe("Object Recall", () => {
 
     expect(sdk.getType("InputAsset", { getRawType: true })).toMatchSnapshot();
   });
+
+  test("Processed", () => {
+    const sdk = new XLRSDK();
+    sdk.loadDefinitionsFromModule(Types);
+    sdk.loadDefinitionsFromModule(ReferenceAssetsWebPluginManifest);
+
+    expect(sdk.getType("InputAsset", { optimize: false })).toMatchSnapshot();
+  });
+
+  test("Optimized", () => {
+    const sdk = new XLRSDK();
+    sdk.loadDefinitionsFromModule(Types);
+    sdk.loadDefinitionsFromModule(ReferenceAssetsWebPluginManifest);
+
+    expect(sdk.getType("InputAsset")).toMatchSnapshot();
+  });
 });
 
-describe("Basic Validation", () => {
+describe("Validation", () => {
   test("Basic Validation By Name", () => {
     const mockAsset = parseTree(`
     {
@@ -86,7 +94,31 @@ describe("Basic Validation", () => {
     expect(sdk.validateByName("InputAsset", mockAsset)).toMatchSnapshot();
   });
 
-  test("Basic Validation By Type", () => {
+  test("Basic Validation By Type (unoptimized)", () => {
+    const mockAsset = parseTree(`
+    {
+      "id": 1,
+      "type": "input",
+      "binding": "some.data",
+      "label": {
+        "asset": {
+          "value": "{{input.label}}"
+        }
+      }
+    `);
+
+    const sdk = new XLRSDK();
+    sdk.loadDefinitionsFromModule(Types);
+    sdk.loadDefinitionsFromModule(ReferenceAssetsWebPluginManifest);
+
+    const inputAsset = sdk.getType("InputAsset", { optimize: false });
+    expect(inputAsset).toBeDefined();
+    expect(
+      sdk.validateByType(inputAsset as NamedType, mockAsset)
+    ).toMatchSnapshot();
+  });
+
+  test("Basic Validation By Type (optimized)", () => {
     const mockAsset = parseTree(`
     {
       "id": 1,

--- a/xlr/sdk/src/sdk.ts
+++ b/xlr/sdk/src/sdk.ts
@@ -303,12 +303,12 @@ export class XLRSDK {
   }
 
   /**
-   * Transforms a generated XLR node into its final representation by
-   * Resolving all `extends` properties
-   * Solving any conditional types
-   * Computing the effective types of any union elements
-   * Resolving any ref nodes
-   * filing in any remaining generics with their default value
+   * Transforms a generated XLR node into its final representation by resolving all `extends` properties.
+   * If `optimize` is set to true the following operations are also performed:
+   *  - Solving any conditional types
+   *  - Computing the effective types of any union elements
+   *  - Resolving any ref nodes
+   *  - filing in any remaining generics with their default value
    */
   private resolveType(type: NamedType, optimize = true): NamedType {
     const resolvedObject = fillInGenerics(type);

--- a/xlr/sdk/src/sdk.ts
+++ b/xlr/sdk/src/sdk.ts
@@ -317,7 +317,7 @@ export class XLRSDK {
       object: [(objectNode: ObjectType) => {
         if (objectNode.extends) {
           const refName = objectNode.extends.ref.split("<")[0];
-          let extendedType = this.getType(refName, { getRawType: true });
+          let extendedType = this.getType(refName);
           if (!extendedType) {
             throw new Error(
               `Error resolving ${objectNode.name}: can't find extended type ${refName}`
@@ -338,6 +338,18 @@ export class XLRSDK {
               name: objectNode.name,
               description: objectNode.description,
             };
+          }
+
+          if( extendedType.type === "or"){
+            return {
+              ...this.validator.computeIntersectionType([
+                objectNode,
+                extendedType
+              ]
+              ),
+              name: objectNode.name,
+              description: objectNode.description,
+            } as any;
           }
 
           // if the merge isn't straightforward, defer until validation time for now

--- a/xlr/sdk/src/sdk.ts
+++ b/xlr/sdk/src/sdk.ts
@@ -317,7 +317,7 @@ export class XLRSDK {
       object: [(objectNode: ObjectType) => {
         if (objectNode.extends) {
           const refName = objectNode.extends.ref.split("<")[0];
-          let extendedType = this.getType(refName);
+          let extendedType = this.getType(refName, {getRawType: true});
           if (!extendedType) {
             throw new Error(
               `Error resolving ${objectNode.name}: can't find extended type ${refName}`

--- a/xlr/sdk/src/sdk.ts
+++ b/xlr/sdk/src/sdk.ts
@@ -1,7 +1,5 @@
 /* eslint-disable prettier/prettier */
 import type {
-  AndType,
-  ConditionalType,
   Manifest,
   NamedType,
   NodeType,
@@ -356,7 +354,7 @@ export class XLRSDK {
 
         return objectNode;
       }],
-      conditional: [      (node) => {
+      conditional: [(node) => {
         return resolveConditional(node) as any
       }],
       and: [(node) => {

--- a/xlr/sdk/src/utils.ts
+++ b/xlr/sdk/src/utils.ts
@@ -164,7 +164,7 @@ export function xlrTransformWalker(
       };
     }
 
-    return n;
+    return node;
   };
 
   return walker;

--- a/xlr/sdk/src/validator.ts
+++ b/xlr/sdk/src/validator.ts
@@ -288,7 +288,7 @@ export class XLRValidator {
     }
   }
 
-  private getRefType(ref: RefType): NodeType {
+  public getRefType(ref: RefType): NodeType {
     let refName = ref.ref;
     if (refName.indexOf("<") > 0) {
       [refName] = refName.split("<");
@@ -312,7 +312,7 @@ export class XLRValidator {
     return exp;
   }
 
-  private computeIntersectionType(types: Array<NodeType>): ObjectType | OrType {
+  public computeIntersectionType(types: Array<NodeType>): ObjectType | OrType {
     let firstElement = types[0];
     let effectiveType: ObjectType | OrType;
 

--- a/xlr/utils/src/ts-helpers.ts
+++ b/xlr/utils/src/ts-helpers.ts
@@ -6,9 +6,10 @@ import type {
   ObjectProperty,
   ObjectType,
   OrType,
+  RefNode,
 } from "@player-tools/xlr";
 import { computeExtends, resolveConditional } from "./validation-helpers";
-import { isGenericNodeType } from "./type-checks";
+import { isGenericNamedType, isGenericNodeType } from "./type-checks";
 
 /**
  * Returns the required type or the optionally required type
@@ -201,6 +202,27 @@ export function fillInGenerics(
     return {
       ...xlrNode,
       properties: newProperties,
+      ...(isGenericNamedType(xlrNode)
+        ? {
+            genericTokens: xlrNode.genericTokens.map((token) => {
+              return {
+                ...token,
+                constraints: token.constraints
+                  ? fillInGenerics(token.constraints, localGenerics)
+                  : undefined,
+                default: token.default
+                  ? fillInGenerics(token.default, localGenerics)
+                  : undefined,
+              };
+            }),
+          }
+        : {}),
+      extends: xlrNode.extends
+        ? (fillInGenerics(xlrNode.extends, localGenerics) as RefNode)
+        : undefined,
+      additionalProperties: xlrNode.additionalProperties
+        ? fillInGenerics(xlrNode.additionalProperties, localGenerics)
+        : false,
     };
   }
 

--- a/xlr/utils/src/ts-helpers.ts
+++ b/xlr/utils/src/ts-helpers.ts
@@ -151,9 +151,10 @@ export function fillInGenerics(
     localGenerics = new Map();
     if (isGenericNodeType(xlrNode)) {
       xlrNode.genericTokens?.forEach((token) => {
+        const genericValue = (token.default ?? token.constraints) as NodeType;
         localGenerics.set(
           token.symbol,
-          (token.default ?? token.constraints) as NodeType
+          fillInGenerics(genericValue, localGenerics)
         );
       });
     }
@@ -227,8 +228,10 @@ export function fillInGenerics(
   }
 
   if (xlrNode.type === "array") {
-    // eslint-disable-next-line no-param-reassign
-    xlrNode.elementType = fillInGenerics(xlrNode.elementType, localGenerics);
+    return {
+      ...xlrNode,
+      elementType: fillInGenerics(xlrNode.elementType, localGenerics),
+    };
   } else if (xlrNode.type === "or" || xlrNode.type === "and") {
     let pointer;
     if (xlrNode.type === "or") {

--- a/xlr/utils/src/validation-helpers.ts
+++ b/xlr/utils/src/validation-helpers.ts
@@ -147,7 +147,7 @@ export function resolveConditional(conditional: ConditionalType): NodeType {
 }
 
 /**
- *
+ * Resolve referenced node with potential generic arguments
  */
 export function resolveReferenceNode(
   genericReference: RefNode,

--- a/xlr/utils/src/validation-helpers.ts
+++ b/xlr/utils/src/validation-helpers.ts
@@ -126,27 +126,24 @@ export function computeExtends(a: NodeType, b: NodeType): boolean {
  */
 export function resolveConditional(conditional: ConditionalType): NodeType {
   const { left, right } = conditional.check;
-  if (isPrimitiveTypeNode(left) && isPrimitiveTypeNode(right)) {
-    const conditionalResult = conditional.value.false;
+  const conditionalResult = computeExtends(left, right)
+    ? conditional.value.true
+    : conditional.value.false;
 
-    // Compose first level generics here since `conditionalResult` won't have them
-    if (isGenericNodeType(conditional)) {
-      const genericMap: Map<string, NodeType> = new Map();
-      conditional.genericTokens.forEach((token) => {
-        genericMap.set(
-          token.symbol,
-          token.default ?? token.constraints ?? { type: "any" }
-        );
-      });
+  // Compose first level generics here since `conditionalResult` won't have them
+  if (isGenericNodeType(conditional)) {
+    const genericMap: Map<string, NodeType> = new Map();
+    conditional.genericTokens.forEach((token) => {
+      genericMap.set(
+        token.symbol,
+        token.default ?? token.constraints ?? { type: "any" }
+      );
+    });
 
-      return fillInGenerics(conditionalResult, genericMap);
-    }
-
-    return conditionalResult;
+    return fillInGenerics(conditionalResult, genericMap);
   }
 
-  // unable to process return original
-  return conditional;
+  return conditionalResult;
 }
 
 /**


### PR DESCRIPTION
## What's Changing

Currently there is an issue if when the generated `template` properties are validated where because the XLR node isn't fully resolved when retrieved from the SDK by the language service, it can't be fully walked to determine what acutually should be there. This PR now makes it so, by default unless disabled, returned a fully resolved XLR from the SDK. This entails resolving:

- `AndTypeNode` which represent type intersections
- `ConditionalTypeNode` which represent dynamic conditional types
- `RefTypeNode` which represent references to other named types

Doing this allows the XLR returned by the SDK to be parsed easier as it is a more complete look at the actual underlying type. As a result of this, validation gets much faster as nodes are now fully resolved once then cached which means that they don't need to be solved repeatedly at during validation.  

### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
XLR - Fully resolve references, intersection types, conditional types, and generic types when returning a type
JSON Language Server - Add generic tokens when constructing template types in transform
Validation - Fix issue validating nested arrays in templates. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.1--canary.125.2996</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.6.1--canary.125.2996
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
