### PR TITLE
[bazel - npm registry] flipper-plugin-player-ui-devtools

### DIFF
--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -4,6 +4,7 @@ load("//helpers:defs.bzl", "vitest_config")
 
 npm_link_all_packages(name = "node_modules")
 
+tsup_config(name = "tsup_config")
 
 vitest_config(name = "vitest_config")
 

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -70,7 +70,7 @@ npm_package(
 js_binary(
     name = "flipper-plugin-player-ui-devtools.npm-publish",
     data = [":flipper-plugin-player-ui-devtools"],
-    native.package_name(),
+    chdir = package_name() + "/" + "flipper-plugin-player-ui-devtools",
     entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",
     include_npm = True,
 )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -57,24 +57,3 @@ js_run_binary(
     stamp = -1,
     tool = ":flipper_pkg",
 )
-
-// js_pipeline(
-//     package_name = "@flipper-plugin-player-ui-devtools",
-//     deps = [
-//         ":node_modules/@player-tools/devtools-client",
-//         ":node_modules/@player-tools/devtools-types",
-//         "//:node_modules/@types/react",
-//         "//:node_modules/react",
-//     ],
-//     test_deps = [
-//         "//:node_modules",
-//         "//:vitest_config",
-//     ],
-//     build_deps = [
-//         "//:node_modules/@oclif/errors",
-//         "//:node_modules/flipper-pkg",
-//     ],
-//     peer_deps = [
-//         "//:node_modules/flipper-plugin",
-//     ]
-// )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -69,7 +69,6 @@ npm_package(
 
 js_binary(
     name = "flipper-plugin-player-ui-devtools.npm-publish",
-    chdir = package_name(),
     data = [":flipper-plugin-player-ui-devtools"],
     entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",
     include_npm = True,

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -66,3 +66,11 @@ npm_package(
     visibility = ["//visibility:public"],
     srcs = [":flipper-desktop-client"],
 )
+
+js_binary(
+    name = "flipper-plugin-player-ui-devtools.npm-publish",
+    chdir = package_name(),
+    data = [":flipper-plugin-player-ui-devtools"],
+    entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",
+    include_npm = True,
+)

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -2,7 +2,6 @@ load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_player//javascript:defs.bzl", "create_package_json")
-load("@rules_player//javascript:defs.bzl", "js_pipeline")
 
 load("//helpers:defs.bzl", "vitest_config")
 
@@ -44,14 +43,11 @@ directory_path(
     path = "bin/run",
 )
 
-js_binary(
-    name = "flipper_pkg",
-    data = ["//:node_modules/flipper-pkg"],
-    entry_point = ":flipper_pkg_entry",
-)
 
-js_run_binary(
-    name = "flipper-desktop-client",
+npm_package(
+    name = "flipper-plugin-player-ui-devtools",
+    visibility = ["//visibility:public"],
+    package = "@player-tools/flipper-plugin-player-ui-devtools",
     srcs = glob(["src/**/*"]) + [":package"] + deps + peer_deps + build_deps,
     args = ["bundle"],
     chdir = package_name(),
@@ -60,23 +56,10 @@ js_run_binary(
     tool = ":flipper_pkg",
 )
 
-js_pipeline(
-    package_name = "@flipper-plugin-player-ui-devtools",
-    deps = [
-        ":node_modules/@player-tools/devtools-client",
-        ":node_modules/@player-tools/devtools-types",
-        "//:node_modules/@types/react",
-        "//:node_modules/react",
-    ],
-    test_deps = [
-        "//:node_modules",
-        "//:vitest_config",
-    ],
-    build_deps = [
-        "//:node_modules/@oclif/errors",
-        "//:node_modules/flipper-pkg",
-    ],
-    peer_deps = [
-        "//:node_modules/flipper-plugin",
-    ]
+js_binary(
+    name = "flipper_pkg",
+    data = ["//:node_modules/flipper-pkg"],
+    entry_point = ":flipper_pkg_entry",
+    # required to make npm to be available in PATH
+    include_npm = True,
 )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -1,6 +1,6 @@
 load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//helpers:defs.bzl", "vitest_config")
+load("//helpers:defs.bzl", "tsup_config", "vitest_config")
 
 npm_link_all_packages(name = "node_modules")
 

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -26,6 +26,8 @@ peer_deps = [
     "//:node_modules/flipper-plugin",
 ]
 
+pkg_name = "flipper-plugin-player-ui-devtools"
+
 create_package_json(
     name = "package",
     base_package_json = "package.json",
@@ -61,16 +63,16 @@ js_run_binary(
 )
 
 npm_package(
-    name="flipper-plugin-player-ui-devtools",
-    package="flipper-plugin-player-ui-devtools",
+    name = pkg_name,
+    package = pkg_name,
     visibility = ["//visibility:public"],
     srcs = [":flipper-desktop-client"] + glob(["src/**/*"]) + [":package"] + deps + peer_deps + build_deps,
 )
 
 js_binary(
-    name = "flipper-plugin-player-ui-devtools.npm-publish",
-    data = [":flipper-plugin-player-ui-devtools"],
-    chdir = package_name() + "/" + "flipper-plugin-player-ui-devtools",
+    name = pkg_name + "npm-publish",
+    data = [":" + pkg_name],
+    chdir = package_name() + "/" + pkg_name,
     entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",
     include_npm = True,
 )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -58,23 +58,23 @@ js_run_binary(
     tool = ":flipper_pkg",
 )
 
-js_pipeline(
-    package_name = "@flipper-plugin-player-ui-devtools",
-    deps = [
-        ":node_modules/@player-tools/devtools-client",
-        ":node_modules/@player-tools/devtools-types",
-        "//:node_modules/@types/react",
-        "//:node_modules/react",
-    ],
-    test_deps = [
-        "//:node_modules",
-        "//:vitest_config",
-    ],
-    build_deps = [
-        "//:node_modules/@oclif/errors",
-        "//:node_modules/flipper-pkg",
-    ],
-    peer_deps = [
-        "//:node_modules/flipper-plugin",
-    ]
-)
+// js_pipeline(
+//     package_name = "@flipper-plugin-player-ui-devtools",
+//     deps = [
+//         ":node_modules/@player-tools/devtools-client",
+//         ":node_modules/@player-tools/devtools-types",
+//         "//:node_modules/@types/react",
+//         "//:node_modules/react",
+//     ],
+//     test_deps = [
+//         "//:node_modules",
+//         "//:vitest_config",
+//     ],
+//     build_deps = [
+//         "//:node_modules/@oclif/errors",
+//         "//:node_modules/flipper-pkg",
+//     ],
+//     peer_deps = [
+//         "//:node_modules/flipper-plugin",
+//     ]
+// )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -1,10 +1,12 @@
-load("@rules_player//javascript:defs.bzl", "js_pipeline")
+load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//helpers:defs.bzl", "tsup_config", "vitest_config")
+load("@rules_player//javascript:defs.bzl", "create_package_json")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+load("//helpers:defs.bzl", "vitest_config")
 
 npm_link_all_packages(name = "node_modules")
-
-tsup_config(name = "tsup_config")
 
 vitest_config(name = "vitest_config")
 
@@ -24,9 +26,50 @@ peer_deps = [
     "//:node_modules/flipper-plugin",
 ]
 
-js_pipeline(
-    package_name = "flipper-plugin-player-ui-devtools",
-    deps = deps,
-    build_deps = build_deps,
-    peer_deps = peer_deps
+create_package_json(
+    name = "package",
+    base_package_json = "package.json",
+    custom_entrypoints = True,
+    dependencies = deps,
+    peer_dependencies = peer_deps,
+    root_package_json = "//:package.json",
+    substitutions = {
+        "0.0.0-PLACEHOLDER": "{STABLE_VERSION}",
+    },
+)
+
+directory_path(
+    name = "flipper_pkg_entry",
+    directory = "//:node_modules/flipper-pkg/dir",
+    path = "bin/run",
+)
+
+js_binary(
+    name = "flipper_pkg",
+    data = ["//:node_modules/flipper-pkg"],
+    entry_point = ":flipper_pkg_entry",
+)
+
+js_run_binary(
+    name = "flipper-desktop-client",
+    srcs = glob(["src/**/*"]) + [":package"] + deps + peer_deps + build_deps,
+    args = ["bundle"],
+    chdir = package_name(),
+    out_dirs = ["dist"],
+    stamp = -1,
+    tool = ":flipper_pkg",
+)
+
+npm_package(
+    name="flipper-plugin-player-ui-devtools",
+    package="flipper-plugin-player-ui-devtools",
+    visibility = ["//visibility:public"],
+    srcs = [":flipper-desktop-client"] + glob(["src/**/*"]) + [":package"] + deps + peer_deps + build_deps,
+)
+
+js_binary(
+    name = "flipper-plugin-player-ui-devtools.npm-publish",
+    data = [":flipper-plugin-player-ui-devtools"],
+    entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",
+    include_npm = True,
 )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -62,7 +62,7 @@ js_run_binary(
 
 npm_package(
     name="flipper-plugin-player-ui-devtools",
-    package="@player/flipper-plugin-player-ui-devtools",
+    package="flipper-plugin-player-ui-devtools",
     visibility = ["//visibility:public"],
     srcs = [":flipper-desktop-client"],
 )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -2,6 +2,8 @@ load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_player//javascript:defs.bzl", "create_package_json")
+load("@rules_player//javascript:defs.bzl", "js_pipeline")
+
 load("//helpers:defs.bzl", "vitest_config")
 
 npm_link_all_packages(name = "node_modules")

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -57,3 +57,24 @@ js_run_binary(
     stamp = -1,
     tool = ":flipper_pkg",
 )
+
+js_pipeline(
+    package_name = "@flipper-plugin-player-ui-devtools",
+    deps = [
+        ":node_modules/@player-tools/devtools-client",
+        ":node_modules/@player-tools/devtools-types",
+        "//:node_modules/@types/react",
+        "//:node_modules/react",
+    ],
+    test_deps = [
+        "//:node_modules",
+        "//:vitest_config",
+    ],
+    build_deps = [
+        "//:node_modules/@oclif/errors",
+        "//:node_modules/flipper-pkg",
+    ],
+    peer_deps = [
+        "//:node_modules/flipper-plugin",
+    ]
+)

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -1,12 +1,9 @@
-load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
+load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@rules_player//javascript:defs.bzl", "create_package_json")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-
 load("//helpers:defs.bzl", "vitest_config")
 
 npm_link_all_packages(name = "node_modules")
+
 
 vitest_config(name = "vitest_config")
 
@@ -26,50 +23,9 @@ peer_deps = [
     "//:node_modules/flipper-plugin",
 ]
 
-create_package_json(
-    name = "package",
-    base_package_json = "package.json",
-    custom_entrypoints = True,
-    dependencies = deps,
-    peer_dependencies = peer_deps,
-    root_package_json = "//:package.json",
-    substitutions = {
-        "0.0.0-PLACEHOLDER": "{STABLE_VERSION}",
-    },
-)
-
-directory_path(
-    name = "flipper_pkg_entry",
-    directory = "//:node_modules/flipper-pkg/dir",
-    path = "bin/run",
-)
-
-js_binary(
-    name = "flipper_pkg",
-    data = ["//:node_modules/flipper-pkg"],
-    entry_point = ":flipper_pkg_entry",
-)
-
-js_run_binary(
-    name = "flipper-desktop-client",
-    srcs = glob(["src/**/*"]) + [":package"] + deps + peer_deps + build_deps,
-    args = ["bundle"],
-    chdir = package_name(),
-    out_dirs = ["dist"],
-    stamp = -1,
-    tool = ":flipper_pkg",
-)
-
-npm_package(
-    name="flipper-plugin-player-ui-devtools",
-    package="flipper-plugin-player-ui-devtools",
-    visibility = ["//visibility:public"],
-    srcs = [":flipper-desktop-client"] + glob(["src/**/*"]) + [":package"] + deps + peer_deps + build_deps,
-)
-
-js_binary(
-    name = "flipper-plugin-player-ui-devtools.npm-publish",
-    data = [":flipper-plugin-player-ui-devtools"],
-    entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",
-    include_npm = True,
+js_pipeline(
+    package_name = "flipper-plugin-player-ui-devtools",
+    deps = deps,
+    build_deps = build_deps,
+    peer_deps = peer_deps
 )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -70,6 +70,7 @@ npm_package(
 js_binary(
     name = "flipper-plugin-player-ui-devtools.npm-publish",
     data = [":flipper-plugin-player-ui-devtools"],
+    native.package_name(),
     entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",
     include_npm = True,
 )

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -70,7 +70,7 @@ npm_package(
 )
 
 js_binary(
-    name = pkg_name + "npm-publish",
+    name = pkg_name + ".npm-publish",
     data = [":" + pkg_name],
     chdir = package_name() + "/" + pkg_name,
     entry_point = "@aspect_rules_js//npm/private:npm_publish_mjs",

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -64,7 +64,7 @@ npm_package(
     name="flipper-plugin-player-ui-devtools",
     package="flipper-plugin-player-ui-devtools",
     visibility = ["//visibility:public"],
-    srcs = [":flipper-desktop-client"],
+    srcs = [":flipper-desktop-client"] + glob(["src/**/*"]) + [":package"] + deps + peer_deps + build_deps,
 )
 
 js_binary(

--- a/devtools/plugins/mobile/flipper-desktop-client/BUILD
+++ b/devtools/plugins/mobile/flipper-desktop-client/BUILD
@@ -2,6 +2,7 @@ load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_player//javascript:defs.bzl", "create_package_json")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 
 load("//helpers:defs.bzl", "vitest_config")
 
@@ -43,11 +44,14 @@ directory_path(
     path = "bin/run",
 )
 
+js_binary(
+    name = "flipper_pkg",
+    data = ["//:node_modules/flipper-pkg"],
+    entry_point = ":flipper_pkg_entry",
+)
 
-npm_package(
-    name = "flipper-plugin-player-ui-devtools",
-    visibility = ["//visibility:public"],
-    package = "@player-tools/flipper-plugin-player-ui-devtools",
+js_run_binary(
+    name = "flipper-desktop-client",
     srcs = glob(["src/**/*"]) + [":package"] + deps + peer_deps + build_deps,
     args = ["bundle"],
     chdir = package_name(),
@@ -56,10 +60,9 @@ npm_package(
     tool = ":flipper_pkg",
 )
 
-js_binary(
-    name = "flipper_pkg",
-    data = ["//:node_modules/flipper-pkg"],
-    entry_point = ":flipper_pkg_entry",
-    # required to make npm to be available in PATH
-    include_npm = True,
+npm_package(
+    name="flipper-plugin-player-ui-devtools",
+    package="@player/flipper-plugin-player-ui-devtools",
+    visibility = ["//visibility:public"],
+    srcs = [":flipper-desktop-client"],
 )

--- a/devtools/plugins/mobile/flipper-desktop-client/package.json
+++ b/devtools/plugins/mobile/flipper-desktop-client/package.json
@@ -2,6 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-player-ui-devtools",
   "id": "player-ui-devtools",
+  "pluginType": "client",
   "version": "0.0.0-PLACEHOLDER",
   "main": "dist/index.js",
   "dependencies": {

--- a/devtools/plugins/mobile/flipper-desktop-client/package.json
+++ b/devtools/plugins/mobile/flipper-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
-  "name": "@player-tools/flipper-plugin-player-ui-devtools",
+  "name": "flipper-plugin-player-ui-devtools",
   "id": "player-ui-devtools",
   "pluginType": "client",
   "version": "0.0.0-PLACEHOLDER",

--- a/devtools/plugins/mobile/flipper-desktop-client/package.json
+++ b/devtools/plugins/mobile/flipper-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
-  "name": "flipper-plugin-player-ui-devtools",
+  "name": "@player-tools/flipper-plugin-player-ui-devtools",
   "id": "player-ui-devtools",
   "pluginType": "client",
   "version": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Bazel build file updates on the `flipper-plugin-player-ui-devtools ` package to get to publish to npm registry again.

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.1--canary.138.3286</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.6.1--canary.138.3286
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
