### PR TITLE
Update CLI to Allow Compilation to any File Type

### DIFF
--- a/cli/src/commands/dsl/compile.ts
+++ b/cli/src/commands/dsl/compile.ts
@@ -136,7 +136,7 @@ export default class DSLCompile extends BaseCommand {
       );
 
       const compileResult = await context.hooks.compileContent.call(
-        { type: contentType as DefaultCompilerContentType },
+        { type: contentType },
         preProcessedValue,
         file
       );

--- a/cli/src/utils/compilation-context.ts
+++ b/cli/src/utils/compilation-context.ts
@@ -9,6 +9,10 @@ export interface identifyContentReturn {
   extension: string;
 }
 
+export interface compileContentArgs extends Omit<SerializeContext, "type"> {
+  type: string;
+}
+
 export interface compilationResult {
   /** the JSON value of the source */
   value: string;
@@ -44,7 +48,7 @@ export class CompilationContext {
      * @returns CompilerReturn object instance or undefined
      */
     compileContent: new AsyncSeriesBailHook<
-      [SerializeContext, any, string],
+      [compileContentArgs, any, string],
       compilationResult
     >(),
   };


### PR DESCRIPTION
Currently, the CLI assumes that any result from the compilation hook is an object that can be serialized to JSON and should be written to a file that ends in `.js`. There are potentially other usecases for compiling Player related content that may not result in a JSON serializable result. This PR expands the results to generalize what the compilation is to be some string that should be written as the output file, and an optional second string that should be written as the source map. 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`

## Release Notes
Allow DSL compilation phase to compile to non `.json` targets

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.0--canary.146.3413</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.7.0--canary.146.3413
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
