### PR TITLE
revert canary on forks

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -26,23 +26,19 @@ jobs:
               repo,
               username,
             });
+
             github.rest.reactions.createForIssueComment({
               owner,
               repo,
               comment_id: context.payload.comment.id,
               content: "eyes",
             });
+            
             const { data: { head: { ref: branch, login: prOwner }}} = await github.rest.pulls.get({
               owner,
               repo,
               pull_number,
             });
-
-            if (prOwner !== "player-ui") {
-              // CircleCI format for triggering PR
-              // https://circleci.com/docs/api/v2/index.html#operation/triggerPipeline
-              return "pull/" + pull_number + "/head";
-            }
 
             return branch;
       - name: Not a collaborator


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Removed the check to make a canary on forks. This check was potentially causing the canary not to release when branches were not from a fork.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->