### PR TITLE
Re-add compiler formatting to dsl output

### DIFF
--- a/cli/src/utils/compilation-context.ts
+++ b/cli/src/utils/compilation-context.ts
@@ -67,7 +67,7 @@ export class CompilationContext {
 
         if (compilationResults) {
           return {
-            value: JSON.stringify(compilationResults.value),
+            value: JSON.stringify(compilationResults.value, null, 2),
             sourceMap: compilationResults.sourceMap,
           };
         }


### PR DESCRIPTION
#146 had a side-effect of removing white space formatting from compiled content. This inadvertently breaks downstream tooling relying on multi-line formatted content. We'll need to re-evaluate the strategy, but this change unblocks upgrades until that is done.

The miss:
https://github.com/player-ui/tools/pull/146/files#diff-1c41b0a3b4f66722dbb6de6aa0db4a7217ddfcbe227ad77e1fc2d8465df2764bL144
https://github.com/player-ui/tools/pull/146/files#diff-8c9606b0dba073f9d586e0e29ded3b630c37916c172f55eb7e6e12d288a2d9b7R70

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.1--canary.153.3460</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.7.1--canary.153.3460
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
