### PR TITLE
Fix Source Maps not Being Generated for DSL Content

### DIFF
--- a/cli/bin/dev
+++ b/cli/bin/dev
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 
-const oclif = require('@oclif/core')
+const oclif = require("@oclif/core");
 
-const path = require('path')
-const project = path.join(__dirname, '..', 'tsconfig.json')
+const path = require("path");
+const project = path.join(__dirname, "..", "tsconfig.json");
 
 // In dev mode -> use ts-node and dev plugins
-process.env.NODE_ENV = 'development'
+process.env.NODE_ENV = "development";
 
-require('ts-node').register({project})
+require("ts-node").register({ project });
 
 // In dev mode, always show stack traces
 oclif.settings.debug = true;
 
 // Start the CLI
-oclif.run().then(oclif.flush).catch(oclif.Errors.handle)
+oclif.run().then(oclif.flush).catch(oclif.Errors.handle);

--- a/cli/bin/run
+++ b/cli/bin/run
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 
-const oclif = require('@oclif/core')
-process.env.NODE_ENV = 'production'
+const oclif = require("@oclif/core");
 
-oclif.run().then(require('@oclif/core/flush')).catch(require('@oclif/core/handle'))
+// Setting this to production break source-map generation for dsl content
+process.env.NODE_ENV = "development";
+
+oclif
+  .run()
+  .then(require("@oclif/core/flush"))
+  .catch(require("@oclif/core/handle"));


### PR DESCRIPTION
Setting the node env to `production` prevents source maps from being generated by the [react-json-reconciler](https://github.com/intuit/react-json-reconciler)

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

## Release Notes
Fix source maps not being generated for DSL content when compiled by the cli