### PR TITLE
feat: doesn't exit with error if warn-only on dsl validation

### DIFF
--- a/cli/src/commands/dsl/compile.ts
+++ b/cli/src/commands/dsl/compile.ts
@@ -42,6 +42,12 @@ export default class DSLCompile extends BaseCommand {
       description: "Use experimental language features",
       default: false,
     }),
+    severity: Flags.string({
+      char: "s",
+      description: "The severity of the validation",
+      options: ["error", "warn"],
+      default: "error",
+    }),
   };
 
   private async getOptions() {
@@ -61,6 +67,7 @@ export default class DSLCompile extends BaseCommand {
       skipValidation:
         flags["skip-validation"] ?? config.dsl?.skipValidation ?? false,
       exp,
+      severity: flags.severity,
     };
   }
 
@@ -68,7 +75,8 @@ export default class DSLCompile extends BaseCommand {
     /** the status code */
     exitCode: number;
   }> {
-    const { input, output, skipValidation, exp } = await this.getOptions();
+    const { input, output, skipValidation, exp, severity } =
+      await this.getOptions();
 
     const files = await glob(
       convertToFileGlob([input], "**/*.(tsx|jsx|js|ts)"),
@@ -86,7 +94,7 @@ export default class DSLCompile extends BaseCommand {
     this.debug("Found %i files to process", files.length);
 
     if (!skipValidation) {
-      await ValidateTSTypes.run(["-f", input]);
+      await ValidateTSTypes.run(["-f", input, "-s", severity]);
     }
 
     const context = await this.createCompilerContext();

--- a/cli/src/commands/dsl/validate.ts
+++ b/cli/src/commands/dsl/validate.ts
@@ -18,6 +18,12 @@ export default class Validate extends BaseCommand {
       description: "A list of files or globs to validate",
       multiple: true,
     }),
+    severity: Flags.string({
+      char: "s",
+      description: "The severity of the validation",
+      options: ["error", "warn"],
+      default: "error",
+    }),
   };
 
   private async getOptions() {
@@ -33,6 +39,7 @@ export default class Validate extends BaseCommand {
 
     return {
       inputFiles: Array.isArray(files) ? files : [files],
+      severity: flags.severity,
     };
   }
 
@@ -82,7 +89,7 @@ export default class Validate extends BaseCommand {
   }
 
   async run(): Promise<void> {
-    const { inputFiles } = await this.getOptions();
+    const { inputFiles, severity } = await this.getOptions();
 
     const files = await glob(
       convertToFileGlob(inputFiles, "**/*.(tsx|jsx|js|ts)"),
@@ -153,7 +160,9 @@ export default class Validate extends BaseCommand {
         ${fileNameList.length} 
         file${fileNameList.length > 1 ? "s" : ""}, exiting program`
       );
-      this.exit(1);
+      if (severity === "error") {
+        this.exit(1);
+      }
     } else {
       this.log(`${logSymbols.success} No TSX types or errors found.`);
     }


### PR DESCRIPTION
## Description

Adds an option to avoid exiting with code 1 if there's a validation error, but the severity of the DSL validation is set to `warn`.


### Change Type

- [ ] `patch`
- [x] `minor`
- [ ] `major`