### PR TITLE
Use bazelrc for Main Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,10 +210,15 @@ workflows:
               only:
                 - main
                 - /version-.*/
+      - bazelrc:
+          context:
+            - BuildTools
+          requires:
+            - setup
 
       - build:
           requires:
-            - setup
+            - bazelrc
 
       - test:
           requires:
@@ -225,7 +230,7 @@ workflows:
           requires:
             - test
 
-  release:
+  full_release:
     when:
       equal: [release, << pipeline.parameters.GHA_Action >>]
     jobs:
@@ -235,9 +240,15 @@ workflows:
           requires:
             - setup
 
+      - bazelrc:
+          context:
+            - BuildTools
+          requires:
+            - setup
+
       - test:
           requires:
-            - build
+            - bazelrc
 
       - release:
           context:


### PR DESCRIPTION
## Release Notes

Use bazelrc to include CI bazel configuration for builds off of main 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->