### PR TITLE
Don't create oclif manifest

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -58,6 +58,7 @@ oclif_pipeline(
     package_name = "@player-tools/cli",
     build_deps = build_deps,
     deps = deps,
+    manifest = False
 )
 
 directory_path(

--- a/cli/package.json
+++ b/cli/package.json
@@ -5,8 +5,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "bin",
-    "dist",
-    "oclif.manifest.json"
+    "dist"
   ],
   "oclif": {
     "bin": "player",


### PR DESCRIPTION
Closes #167. A manifest is not technically required so instead of figuring out how to stamp it correctly we can just remove it from the generation pipeline. 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Fixes issue with oclif manifest not being stamped with the right version leading to console errors