### PR TITLE
Add options to LSPAssetsPlugin to load from TSManifest via module import

### DIFF
--- a/cli/src/plugins/LSPAssetsPlugin.ts
+++ b/cli/src/plugins/LSPAssetsPlugin.ts
@@ -1,13 +1,41 @@
 import type { PlayerLanguageService } from "@player-tools/json-language-service";
 import type { PlayerCLIPlugin } from "./index";
+import { TSManifest } from "@player-tools/xlr";
 
-export interface LSPAssetsPluginConfig {
-  /** the path to the asset library to load */
+/** Loads XLRs into the LSP via the manifest.js file */
+export interface LSPAssetsPluginModuleConfig {
+  type: "module";
+
+  /** Result of module import/require of xlr manifest.js file */
+  manifest: TSManifest;
+}
+
+/** Loads XLRs to the LSP by specifying a filesystem location */
+export interface LSPAssetsPluginManifestConfig {
+  type: "manifest";
+
+  /** Path to dist folder for XLR enabled plugins */
   path: string;
+}
 
+/**
+ * Legacy type for providing XLR manifest paths that assumes its a manifest
+ * @deprecated
+ * */
+export interface LSPAssetsPluginLegacyConfig {
+  type?: undefined;
+  path: string;
+}
+
+export type LSPAssetPluginConfigTypes =
+  | LSPAssetsPluginModuleConfig
+  | LSPAssetsPluginManifestConfig
+  | LSPAssetsPluginLegacyConfig;
+
+export type LSPAssetsPluginConfig = LSPAssetPluginConfigTypes & {
   /** Provides experimental language features */
   exp?: boolean;
-}
+};
 
 /**
  * Handles setting the assets when loading the LSP
@@ -36,9 +64,26 @@ export class LSPAssetsPlugin implements PlayerCLIPlugin {
     exp: boolean
   ): Promise<void> {
     if (Array.isArray(this.config)) {
-      await lsp.setAssetTypes(this.config.map((c) => c.path));
+      await Promise.all(
+        this.config.map((c) => {
+          this.loadConfig(c, lsp);
+        })
+      );
     } else {
-      await lsp.setAssetTypes([this.config.path]);
+      await this.loadConfig(this.config, lsp);
+    }
+  }
+
+  async loadConfig(
+    config: LSPAssetPluginConfigTypes,
+    lsp: PlayerLanguageService
+  ): Promise<void> {
+    if (config.type === "manifest" || config.type === undefined) {
+      await lsp.setAssetTypes([config.path]);
+    } else if (config.type === "module") {
+      await lsp.setAssetTypesFromModule([config.manifest]);
+    } else {
+      throw Error(`Unknown config type: ${(config as any).type}`);
     }
   }
 }

--- a/cli/src/plugins/__tests__/LSPAssetsPlugin.test.ts
+++ b/cli/src/plugins/__tests__/LSPAssetsPlugin.test.ts
@@ -1,0 +1,69 @@
+import { PlayerLanguageService } from "@player-tools/json-language-service";
+import { vi, test, expect, describe, beforeEach } from "vitest";
+import { LSPAssetsPlugin } from "../LSPAssetsPlugin";
+
+describe("LSPAssetPlugin tests", () => {
+  const mockSetAssetTypes = vi.fn();
+  const mockSetAssetTypesFromModule = vi.fn();
+
+  const mockLSP: PlayerLanguageService = {
+    setAssetTypes: mockSetAssetTypes,
+    setAssetTypesFromModule: mockSetAssetTypesFromModule,
+  } as unknown as PlayerLanguageService;
+
+  beforeEach(() => {
+    mockSetAssetTypes.mockClear();
+    mockSetAssetTypesFromModule.mockClear();
+  });
+
+  test("It should load assets from the filesystem by default (legacy)", async () => {
+    const testPlugin = new LSPAssetsPlugin({ path: "some/path" });
+    await testPlugin.onCreateLanguageService(mockLSP, false);
+
+    expect(mockSetAssetTypes).toHaveBeenCalledWith(["some/path"]);
+    expect(mockSetAssetTypesFromModule).not.toHaveBeenCalled();
+  });
+
+  test("It should load assets from the filesystem ", async () => {
+    const testPlugin = new LSPAssetsPlugin({
+      path: "some/path",
+      type: "manifest",
+    });
+    await testPlugin.onCreateLanguageService(mockLSP, false);
+
+    expect(mockSetAssetTypes).toHaveBeenCalledWith(["some/path"]);
+    expect(mockSetAssetTypesFromModule).not.toHaveBeenCalled();
+  });
+
+  test("It should load assets from a module", async () => {
+    const testPlugin = new LSPAssetsPlugin({
+      manifest: { pluginName: "test", capabilities: {} },
+      type: "module",
+    });
+    await testPlugin.onCreateLanguageService(mockLSP, false);
+
+    expect(mockSetAssetTypesFromModule).toHaveBeenCalledWith([
+      {
+        pluginName: "test",
+        capabilities: {},
+      },
+    ]);
+    expect(mockSetAssetTypes).not.toHaveBeenCalled();
+  });
+
+  test("It should load assets from a mixed config", async () => {
+    const testPlugin = new LSPAssetsPlugin([
+      { manifest: { pluginName: "test", capabilities: {} }, type: "module" },
+      { path: "some/path", type: "manifest" },
+    ]);
+    await testPlugin.onCreateLanguageService(mockLSP, false);
+
+    expect(mockSetAssetTypesFromModule).toHaveBeenCalledWith([
+      {
+        pluginName: "test",
+        capabilities: {},
+      },
+    ]);
+    expect(mockSetAssetTypes).toHaveBeenCalledWith(["some/path"]);
+  });
+});


### PR DESCRIPTION
Closes #98 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Allow for loading XLRs to LSP via module imports. Add explicit (optional for now) toggle for distinguishing between module and manifest loading. 