### PR TITLE
PR Comment Version Fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,26 +51,8 @@ commands:
             $PACKAGE_VERSION
             \`\`\`"
 
-            # Debug information
-            echo "PR_NUMBER: ${PR_NUMBER:-not set}"
-            echo "PACKAGE_VERSION: ${PACKAGE_VERSION:-not set}"
-            echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH:-not set}"
-
-            if [ -n "$PR_NUMBER" ]; then
-              echo "Posting comment to PR #$PR_NUMBER"
-              # Use set +e to prevent the command from failing the build if it errors
-              set +e
-              npx auto comment --pr $PR_NUMBER --context "Build Info" --message "$BUILD_INFO"
-              COMMENT_EXIT_CODE=$?
-              set -e
-              
-              if [ $COMMENT_EXIT_CODE -ne 0 ]; then
-                echo "Warning: Failed to post comment to PR, but continuing build"
-                echo "This is expected for merge builds where PR_NUMBER is no longer valid"
-              fi
-            else
-              echo "No PR number found. This is normal for merge builds. Skipping comment posting."
-            fi
+            # Post the build info as a comment to the PR
+            npx auto comment --context "Build Info" --message "$BUILD_INFO" || true
 
   check_branch_status:
     description: "Check if the branch is clean after the build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,13 @@ commands:
             $PACKAGE_VERSION
             \`\`\`"
 
-            # Post the build info as a comment to the PR
-            npx auto comment --pr $PR_NUMBER --context "Build Info" --message "$BUILD_INFO"
+            # Only post the comment if PR_NUMBER is available
+            if [ -n "$PR_NUMBER" ]; then
+              # Post the build info as a comment to the PR
+              npx auto comment --pr $PR_NUMBER --context "Build Info" --message "$BUILD_INFO"
+            else
+              echo "No PR number found. Skipping comment posting."
+            fi
 
   check_branch_status:
     description: "Check if the branch is clean after the build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,25 @@ commands:
             $PACKAGE_VERSION
             \`\`\`"
 
-            # Only post the comment if PR_NUMBER is available
+            # Debug information
+            echo "PR_NUMBER: ${PR_NUMBER:-not set}"
+            echo "PACKAGE_VERSION: ${PACKAGE_VERSION:-not set}"
+            echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH:-not set}"
+
             if [ -n "$PR_NUMBER" ]; then
-              # Post the build info as a comment to the PR
+              echo "Posting comment to PR #$PR_NUMBER"
+              # Use set +e to prevent the command from failing the build if it errors
+              set +e
               npx auto comment --pr $PR_NUMBER --context "Build Info" --message "$BUILD_INFO"
+              COMMENT_EXIT_CODE=$?
+              set -e
+              
+              if [ $COMMENT_EXIT_CODE -ne 0 ]; then
+                echo "Warning: Failed to post comment to PR, but continuing build"
+                echo "This is expected for merge builds where PR_NUMBER is no longer valid"
+              fi
             else
-              echo "No PR number found. Skipping comment posting."
+              echo "No PR number found. This is normal for merge builds. Skipping comment posting."
             fi
 
   check_branch_status:


### PR DESCRIPTION
Fixing an issue where the CI was erroring out when there was no PR (when a PR is going into main, etc).

Caused by https://github.com/player-ui/tools/pull/203

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.1--canary.205.4524</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.9.1--canary.205.4524
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
