### PR TITLE
DSL Expression Generation Functions

### DIFF
--- a/language/dsl/src/__tests__/util.test.tsx
+++ b/language/dsl/src/__tests__/util.test.tsx
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "vitest";
-import { getObjectReferences, wrapFunctionInType } from "../utils";
+import { getObjectReferences, mapExpressionHandlersToFunctions, wrapFunctionInType } from "../utils";
 import { Binding, Expression, ExpressionHandler } from "@player-ui/player";
 import { binding, expression } from "../string-templates";
 
@@ -60,7 +60,10 @@ describe("DSL Expression Generation Helper", () => {
   });
 
   test("Returns the correct serialization for array items", () => {
-    const mockFunction: ExpressionHandler<[Array<unknown>], boolean> = (ctx, val) => {
+    const mockFunction: ExpressionHandler<[Array<unknown>], boolean> = (
+      ctx,
+      val,
+    ) => {
       return false;
     };
 
@@ -88,7 +91,10 @@ describe("DSL Expression Generation Helper", () => {
   });
 
   test("Can Pass Nested Expressions", () => {
-    const mockFunction: ExpressionHandler<[Expression, number], boolean> = (ctx, val) => {
+    const mockFunction: ExpressionHandler<[Expression, number], boolean> = (
+      ctx,
+      val,
+    ) => {
       return false;
     };
 
@@ -99,5 +105,24 @@ describe("DSL Expression Generation Helper", () => {
     const test = expression`${mockFunctionDSL(bar, 1)}`;
 
     expect(test.toValue()).toEqual("mockFunction('{{foo.bar}} != 1', 1)");
+  });
+
+  test("Export Generator", () => {
+    const mockFunction: ExpressionHandler<[string, number], boolean> = (
+      ctx,
+      val,
+    ) => {
+      return false;
+    };
+    const expressionFunctions = { mockFunction };
+
+    const usableFunctions =
+      mapExpressionHandlersToFunctions<typeof expressionFunctions>(
+        expressionFunctions,
+      );
+
+    expect(usableFunctions.mockFunction("1", 0).toValue()).toMatch(
+      "mockFunction('1', 0)",
+    );
   });
 });

--- a/language/dsl/src/__tests__/util.test.tsx
+++ b/language/dsl/src/__tests__/util.test.tsx
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "vitest";
 import { getObjectReferences, wrapFunctionInType } from "../utils";
-import { Expression, ExpressionHandler } from "@player-ui/player";
+import { Binding, Expression, ExpressionHandler } from "@player-ui/player";
 import { binding, expression } from "../string-templates";
 
 describe("Testing the 'getObjectReferences' helper that creates same property references into a new object", () => {
@@ -27,9 +27,9 @@ describe("Testing the 'getObjectReferences' helper that creates same property re
   });
 });
 
-describe("DSL Generation Helper", () => {
+describe("DSL Expression Generation Helper", () => {
   test("Returns the correct serialization for bindings", () => {
-    const mockFunction: ExpressionHandler<[unknown], boolean> = (ctx, val) => {
+    const mockFunction: ExpressionHandler<[Binding], boolean> = (ctx, val) => {
       return false;
     };
 
@@ -42,20 +42,20 @@ describe("DSL Generation Helper", () => {
   });
 
   test("Returns the correct serialization for mixed values and bindings", () => {
-    const mockFunction: ExpressionHandler<
-      [unknown, string, number],
-      boolean
-    > = (ctx, val) => {
+    const mockFunction: ExpressionHandler<[string, string, number], boolean> = (
+      ctx,
+      val,
+    ) => {
       return false;
     };
 
     const mockFunctionDSL = wrapFunctionInType(mockFunction);
 
     const foo = binding`some.binding`;
-    const test = expression`${mockFunctionDSL(foo, "test", 1)} == true`;
+    const test = expression`${mockFunctionDSL(foo.toRefString(), "test", 1)} == true`;
 
     expect(test.toValue()).toEqual(
-      "mockFunction('some.binding', 'test', 1) == true",
+      "mockFunction('{{some.binding}}', 'test', 1) == true",
     );
   });
 
@@ -67,14 +67,14 @@ describe("DSL Generation Helper", () => {
     const mockFunctionDSL = wrapFunctionInType(mockFunction);
 
     const foo = binding`some.binding`;
-    const test = expression`${mockFunctionDSL([1, "2", foo.toRefString()])}`;
+    const test = expression`${mockFunctionDSL([1, "2", foo])}`;
 
     expect(test.toValue()).toEqual(
       "mockFunction([1, '2', '{{some.binding}}'])",
     );
   });
 
-  test("Can Pass dereferenced Binding", () => {
+  test("Can Dereferenced Binding", () => {
     const mockFunction: ExpressionHandler<[string], boolean> = (ctx, val) => {
       return false;
     };
@@ -87,7 +87,7 @@ describe("DSL Generation Helper", () => {
     expect(test.toValue()).toEqual("mockFunction('{{some.binding}}') == true");
   });
 
-  test("Can Pass nested Expressions", () => {
+  test("Can Pass Nested Expressions", () => {
     const mockFunction: ExpressionHandler<[Expression, number], boolean> = (ctx, val) => {
       return false;
     };

--- a/language/dsl/src/__tests__/util.test.tsx
+++ b/language/dsl/src/__tests__/util.test.tsx
@@ -1,5 +1,7 @@
 import { test, expect, describe } from "vitest";
-import { getObjectReferences } from "../utils";
+import { getObjectReferences, wrapFunctionInType } from "../utils";
+import { ExpressionHandler } from "@player-ui/player";
+import { binding, expression } from "../string-templates";
 
 describe("Testing the 'getObjectReferences' helper that creates same property references into a new object", () => {
   test("should return the object properties in referenced format", () => {
@@ -22,5 +24,38 @@ describe("Testing the 'getObjectReferences' helper that creates same property re
       type: "BooleanType",
     });
     expect(validatorReferences.requiredRef).toStrictEqual({ type: "required" });
+  });
+});
+
+describe("DSL Generation Helper", () => {
+  test("Returns the correct serialization for bindings", () => {
+    const mockFunction: ExpressionHandler<[unknown], boolean> = (ctx, val) => {
+      return false;
+    };
+
+    const mockFunctionDSL = wrapFunctionInType(mockFunction);
+
+    const foo = binding`some.binding`;
+    const test = expression`${mockFunctionDSL(foo)} == true`;
+
+    expect(test.toValue()).toEqual("mockFunction('some.binding') == true");
+  });
+
+  test("Returns the correct serialization for mixed values and bindings", () => {
+    const mockFunction: ExpressionHandler<
+      [unknown, string, number],
+      boolean
+    > = (ctx, val) => {
+      return false;
+    };
+
+    const mockFunctionDSL = wrapFunctionInType(mockFunction);
+
+    const foo = binding`some.binding`;
+    const test = expression`${mockFunctionDSL(foo, "test", 1)} == true`;
+
+    expect(test.toValue()).toEqual(
+      "mockFunction('some.binding', 'test', 1) == true",
+    );
   });
 });

--- a/language/dsl/src/types.ts
+++ b/language/dsl/src/types.ts
@@ -9,6 +9,7 @@ import type {
   BindingTemplateInstance,
   ExpressionTemplateInstance,
 } from "./string-templates";
+import { ExpressionHandler } from "@player-ui/player";
 
 export type WithChildren<T = Record<string, unknown>> = T & {
   /** child nodes */
@@ -149,3 +150,15 @@ export interface DSLSchema<DataTypeRef = DataTypeReference> {
     | [DSLSchema<DataTypeRef>]
     | DSLSchema<DataTypeRef>;
 }
+
+type ExpressionHandlerToFunction<T extends ExpressionHandler> =
+  T extends ExpressionHandler<infer A>
+    ? (...args: A) => ExpressionTemplateInstance
+    : undefined;
+
+export type ExpressionArray<T> =
+  T extends Record<any, any>
+    ? {
+        [P in keyof T]: ExpressionHandlerToFunction<T[P]>;
+      }
+    : undefined;

--- a/language/dsl/src/utils.tsx
+++ b/language/dsl/src/utils.tsx
@@ -6,7 +6,7 @@ import {
   isTemplateStringInstance,
   TemplateStringComponent,
 } from "./string-templates";
-import type { toJsonOptions, WithTemplateTypes } from "./types";
+import type { ExpressionArray, toJsonOptions, WithTemplateTypes } from "./types";
 import { ExpressionHandler } from "@player-ui/player";
 
 /** Get an array version of the value */
@@ -218,4 +218,17 @@ export function wrapFunctionInType<T extends Array<unknown>, R>(
   return (...args: WithTemplateTypes<T>): ExpressionTemplateInstance => {
     return generateDSLFunction(fn.name, args) as ExpressionTemplateInstance;
   };
+}
+
+/**
+ * Takes map of functions and wraps them in a DSL syntax generator
+ */
+export function mapExpressionHandlersToFunctions<
+  T extends Record<string, ExpressionHandler<any, any>>,
+>(functions: T): ExpressionArray<T> {
+  const result: any = {};
+  for (const fn of Object.values(functions)) {
+    result[fn.name] = wrapFunctionInType(fn);
+  }
+  return result;
 }

--- a/language/dsl/src/utils.tsx
+++ b/language/dsl/src/utils.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {
   expression,
   ExpressionTemplateInstance,
+  isBindingTemplateInstance,
   isTemplateStringInstance,
   TemplateStringComponent,
 } from "./string-templates";
@@ -187,11 +188,11 @@ export function getObjectReferences<
   return result;
 }
 
-function parseArg(arg: unknown): any {
+function parseArg(arg: unknown, deref = false): any {
   if (isTemplateStringInstance(arg)) {
-    return `'${arg.toValue()}'`;
+    return `'${deref ? arg.toRefString() : arg.toValue()}'`;
   } else if (Array.isArray(arg)) {
-    return `[${arg.map(parseArg).join(", ")}]`;
+    return `[${arg.map((a) => parseArg(a, true)).join(", ")}]`;
   } else if (typeof arg === "string") {
     return `'${arg}'`;
   } else {
@@ -214,7 +215,7 @@ export function generateDSLFunction(
 export function wrapFunctionInType<T extends Array<unknown>, R>(
   fn: ExpressionHandler<T, R>,
 ): (...args: WithTemplateTypes<T>) => ExpressionTemplateInstance {
-  return (...args): ExpressionTemplateInstance => {
+  return (...args: WithTemplateTypes<T>): ExpressionTemplateInstance => {
     return generateDSLFunction(fn.name, args) as ExpressionTemplateInstance;
   };
 }


### PR DESCRIPTION
Similar to how we have helpers to make DataTypes and Validations usable in DSL. This PR adds a wrapping/mapping logic for Player expressions to have them generate a utility to make using them in DSL content much more ergonomic. The generator functions have the same argument types (and variable names if present) as the underlying functions that are in Player to give hints to content authors about what data is expected. 

The one thing that isn't really possible is automatically determining if a binding should be used as a value or as a reference as its valid to use either in any case where a `Binding` is required by the original function. This initial implementation assumes (and open to feedback here) that if you pass a binding in you want to use it as the binding itself, not its dereferenced value. 

As a follow up, we should investigate how we can tag the `DataRef`s that we generate with their correct primitive types to validate the types that will be used when a Binding is passed in as well as allowing Expressions to correctly denote their return type so that can be cascaded as well. 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`

## Release Notes
Add helper functions to generate usable DSL expressions from Player expressions, allowing better ergonomics when using them in content. 