### PR TITLE
feat: add useRef to the dsl-lite

### DIFF
--- a/language/dsl-lite/src/__tests__/useRef.test.tsx
+++ b/language/dsl-lite/src/__tests__/useRef.test.tsx
@@ -1,0 +1,101 @@
+/** @jsx createElement */
+import { createElement } from "../jsx-runtime";
+import { describe, test, expect } from "vitest";
+import { render } from "../render";
+import { useRef } from "../hooks";
+import type {
+  ASTNode,
+  ObjectASTNode,
+  PropertyASTNode,
+  ValueASTNode,
+  RefObject,
+} from "../types";
+import { createPropertyNode } from "../nodes";
+
+describe("useRef hook", () => {
+  test("useRef basic functionality", () => {
+    // Create a ref with initial value
+    const ref = useRef<number>(42);
+    expect(ref.current).toBe(42);
+
+    // Update the ref
+    ref.current = 100;
+    expect(ref.current).toBe(100);
+  });
+
+  test("useRef with null initial value", () => {
+    const ref = useRef<ASTNode>(null);
+    expect(ref.current).toBeNull();
+  });
+
+  test("useRef with AST nodes through jsx ref prop", () => {
+    // Create refs with specific AST node types
+    const objRef = useRef<ObjectASTNode>(null);
+    const propRef = useRef<PropertyASTNode>(null);
+    const valueRef = useRef<ValueASTNode>(null);
+
+    const element = (
+      <obj ref={objRef}>
+        <property name="test" ref={propRef} value="value1" />
+        <value ref={valueRef} value={42} />
+      </obj>
+    );
+
+    render(element);
+
+    // Verify the refs contain the right nodes
+    expect(objRef.current).not.toBeNull();
+    expect(objRef.current?.kind).toBe("obj");
+    expect(propRef.current?.kind).toBe("property");
+    expect(valueRef.current?.kind).toBe("value");
+  });
+
+  test("useRef in component function", () => {
+    let myRef!: RefObject<ObjectASTNode | null>;
+
+    // Component using refs
+    const TestComponent = () => {
+      myRef = useRef<ObjectASTNode>(null);
+
+      return (
+        <obj ref={myRef}>
+          <property name="test" value="value1" />
+        </obj>
+      );
+    };
+
+    render(<TestComponent />);
+    expect(myRef.current).not.toBeNull();
+    expect(myRef.current?.kind).toBe("obj");
+  });
+
+  test("Accessing and modifying AST nodes via refs", () => {
+    // Create a ref to hold an object AST node
+    const objRef = useRef<ObjectASTNode>(null);
+
+    // Initial render
+    const element = (
+      <obj ref={objRef}>
+        <property name="count" value={0} />
+      </obj>
+    );
+
+    render(element);
+    expect(objRef.current).not.toBeNull();
+
+    // Modify the AST node directly via ref adding a new property to the object node
+    const newProp = createPropertyNode("modified", true);
+    objRef.current?.children.push(newProp);
+    newProp.parent = objRef.current;
+
+    // Custom assertion to check if the modified AST has the right properties
+    expect(objRef.current?.children.length).toBeGreaterThan(1);
+    expect(
+      objRef.current?.children.some(
+        (child) =>
+          child.kind === "property" &&
+          (child as PropertyASTNode).name === "modified",
+      ),
+    ).toBe(true);
+  });
+});

--- a/language/dsl-lite/src/hooks.ts
+++ b/language/dsl-lite/src/hooks.ts
@@ -5,6 +5,7 @@ import type {
   Provider,
   JSXElement,
   ProviderProps,
+  RefObject,
 } from "./types";
 
 const componentKeys = new Map<ComponentType, string>();
@@ -67,6 +68,16 @@ export function popContext(): void {
  */
 export function getCurrentComponent(): ComponentType | null {
   return currentComponent;
+}
+
+/**
+ * Creates a mutable ref object with an initial value.
+ *
+ * This hook mimics React's useRef hook but is designed for use within
+ * the DSL context, allowing references to AST nodes instead of DOM elements.
+ */
+export function useRef<T>(initialValue: T | null = null): RefObject<T | null> {
+  return { current: initialValue };
 }
 
 export function resetHookState() {

--- a/language/dsl-lite/src/types.ts
+++ b/language/dsl-lite/src/types.ts
@@ -108,7 +108,7 @@ export interface JSXComponent<P = Record<string, unknown>> {
 }
 
 export interface RefObject<T> {
-  current: T;
+  current: T | null;
 }
 
 export interface FragmentProps {
@@ -117,7 +117,7 @@ export interface FragmentProps {
 
 export interface IntrinsicElementProps {
   children?: JSXElement | JSXElement[];
-  ref?: RefObject<ASTNode>;
+  ref?: RefObject<ASTNode | null>;
   name?: string;
   value?: JsonType;
   [key: string]: unknown;


### PR DESCRIPTION
fix #200 

## Description

Implement a `useRef` hook that allows content authors to access AST nodes directly. This will provide a way for authors to get references to AST nodes for advanced use cases.

### Change Type (required)
Indicate the type of change your pull request is:

- [ ] `patch`
- [x] `minor`
- [ ] `major`