### PR TITLE
Fix deps for utils for xlr converters package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,7 +191,7 @@ importers:
         version: 10.46.0(@types/node@18.19.34)(typescript@5.5.4)
       babel-loader:
         specifier: ^8.2.5
-        version: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0)
+        version: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0(webpack-cli@3.3.12))
       bundle-analyzer:
         specifier: ^0.0.6
         version: 0.0.6
@@ -221,7 +221,7 @@ importers:
         version: 3.1.8
       css-loader:
         specifier: ^3.6.0
-        version: 3.6.0(webpack@4.47.0)
+        version: 3.6.0(webpack@4.47.0(webpack-cli@3.3.12))
       dequal:
         specifier: ^2.0.2
         version: 2.0.3
@@ -326,7 +326,7 @@ importers:
         version: 1.0.4
       modify-source-webpack-plugin:
         specifier: ^4.1.0
-        version: 4.1.0(webpack@4.47.0)
+        version: 4.1.0(webpack@4.47.0(webpack-cli@3.3.12))
       oclif:
         specifier: ^4.4.2
         version: 4.13.6
@@ -398,7 +398,7 @@ importers:
         version: 1.0.1
       style-loader:
         specifier: ^1.3.0
-        version: 1.3.0(webpack@4.47.0)
+        version: 1.3.0(webpack@4.47.0(webpack-cli@3.3.12))
       tapable-ts:
         specifier: ^0.2.4
         version: 0.2.4
@@ -603,15 +603,16 @@ importers:
 
   xlr/converters:
     dependencies:
-      '@player-tools/test-utils':
-        specifier: workspace:*
-        version: link:../../common/test-utils
       '@player-tools/xlr':
         specifier: workspace:*
         version: link:../types
       '@player-tools/xlr-utils':
         specifier: workspace:*
         version: link:../utils
+    devDependencies:
+      '@player-tools/test-utils':
+        specifier: workspace:*
+        version: link:../../common/test-utils
 
   xlr/sdk:
     dependencies:
@@ -633,12 +634,13 @@ importers:
 
   xlr/utils:
     dependencies:
-      '@player-tools/test-utils':
-        specifier: workspace:*
-        version: link:../../common/test-utils
       '@player-tools/xlr':
         specifier: workspace:*
         version: link:../types
+    devDependencies:
+      '@player-tools/test-utils':
+        specifier: workspace:*
+        version: link:../../common/test-utils
 
 packages:
 
@@ -11259,8 +11261,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -11309,8 +11311,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.587.0
@@ -11367,11 +11369,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.596.0':
+  '@aws-sdk/client-sso-oidc@3.596.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -11410,6 +11412,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.592.0':
@@ -11455,11 +11458,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)':
+  '@aws-sdk/client-sts@3.596.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -11498,7 +11501,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.592.0':
@@ -11532,7 +11534,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/credential-provider-env': 3.587.0
       '@aws-sdk/credential-provider-http': 3.596.0
       '@aws-sdk/credential-provider-process': 3.587.0
@@ -11590,7 +11592,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.587.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.1
       '@smithy/types': 3.1.0
@@ -11706,7 +11708,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.587.0(@aws-sdk/client-sso-oidc@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.1
       '@smithy/shared-ini-file-loader': 3.1.1
@@ -16852,7 +16854,7 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
 
-  babel-loader@8.3.0(@babel/core@7.24.7)(webpack@4.47.0):
+  babel-loader@8.3.0(@babel/core@7.24.7)(webpack@4.47.0(webpack-cli@3.3.12)):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 3.3.2
@@ -17787,7 +17789,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  css-loader@3.6.0(webpack@4.47.0):
+  css-loader@3.6.0(webpack@4.47.0(webpack-cli@3.3.12)):
     dependencies:
       camelcase: 5.3.1
       cssesc: 3.0.0
@@ -21179,7 +21181,7 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  modify-source-webpack-plugin@4.1.0(webpack@4.47.0):
+  modify-source-webpack-plugin@4.1.0(webpack@4.47.0(webpack-cli@3.3.12)):
     dependencies:
       loader-utils-webpack-v4: loader-utils@2.0.4
       schema-utils: 4.2.0
@@ -23660,7 +23662,7 @@ snapshots:
 
   strnum@1.0.5: {}
 
-  style-loader@1.3.0(webpack@4.47.0):
+  style-loader@1.3.0(webpack@4.47.0(webpack-cli@3.3.12)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.1
@@ -23797,7 +23799,7 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@1.4.5(webpack@4.47.0):
+  terser-webpack-plugin@1.4.5(webpack@4.47.0(webpack-cli@3.3.12)):
     dependencies:
       cacache: 12.0.4
       find-cache-dir: 2.1.0
@@ -24523,7 +24525,7 @@ snapshots:
       node-libs-browser: 2.2.1
       schema-utils: 1.0.0
       tapable: 1.1.3
-      terser-webpack-plugin: 1.4.5(webpack@4.47.0)
+      terser-webpack-plugin: 1.4.5(webpack@4.47.0(webpack-cli@3.3.12))
       watchpack: 1.7.5
       webpack-sources: 1.4.3
     optionalDependencies:

--- a/xlr/converters/package.json
+++ b/xlr/converters/package.json
@@ -4,7 +4,9 @@
   "main": "src/index.ts",
   "dependencies": {
     "@player-tools/xlr": "workspace:*",
-    "@player-tools/xlr-utils": "workspace:*",
+    "@player-tools/xlr-utils": "workspace:*"
+  },
+  "devDependencies": {
     "@player-tools/test-utils": "workspace:*"
   }
 }


### PR DESCRIPTION
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

# Release Notes

Fix `@player-tools/xlr-converters` dependency on non-published package `@player-tools/test-utils` which is only needed as part of tests.

Related to https://github.com/player-ui/tools/pull/211
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.2--canary.215.4733</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.10.2--canary.215.4733
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
