### PR TITLE
feat: Metrics Output Plugin should aggregate data

### DIFF
--- a/language/metrics-output-plugin/BUILD
+++ b/language/metrics-output-plugin/BUILD
@@ -23,5 +23,6 @@ js_pipeline(
         "//:node_modules/vscode-languageserver-types",
         "//:node_modules/vscode-languageserver-textdocument",
         "//:node_modules/typescript",
+        "//:node_modules/ts-deepmerge",
     ],
 )

--- a/language/metrics-output-plugin/package.json
+++ b/language/metrics-output-plugin/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0-PLACEHOLDER",
   "main": "src/index.ts",
   "dependencies": {
-    "@player-tools/json-language-service": "workspace:*",
-    "ts-deepmerge": "^7.0.3"
+    "@player-tools/json-language-service": "workspace:*"
   },
   "devDependencies": {
     "@player-tools/static-xlrs": "workspace:*",

--- a/language/metrics-output-plugin/package.json
+++ b/language/metrics-output-plugin/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0-PLACEHOLDER",
   "main": "src/index.ts",
   "dependencies": {
-    "@player-tools/json-language-service": "workspace:*"
+    "@player-tools/json-language-service": "workspace:*",
+    "ts-deepmerge": "^7.0.3"
   },
   "devDependencies": {
     "@player-tools/static-xlrs": "workspace:*",

--- a/language/metrics-output-plugin/src/__tests__/metrics-output-plugin.test.ts
+++ b/language/metrics-output-plugin/src/__tests__/metrics-output-plugin.test.ts
@@ -403,6 +403,44 @@ describe("WriteMetricsPlugin", () => {
     fs.unlinkSync(outputPath);
   });
 
+  test("function-based rootProperties that returns a non-object", async () => {
+    const service = new PlayerLanguageService();
+
+    service.addLSPPlugin(
+      new MetricsOutput({
+        outputDir: TEST_DIR,
+        fileName: "non_object",
+        rootProperties: () => "This should be wrapped in an object",
+      }),
+    );
+
+    await service.setAssetTypesFromModule([
+      Types,
+      ReferenceAssetsWebPluginManifest,
+    ]);
+
+    const document = TextDocument.create(
+      "non/object/test.json",
+      "json",
+      1,
+      JSON.stringify({ id: "test" }),
+    );
+
+    await service.validateTextDocument(document);
+
+    const outputPath = path.join(TEST_DIR, "non_object.json");
+    expect(fs.existsSync(outputPath)).toBe(true);
+
+    const content = JSON.parse(fs.readFileSync(outputPath, "utf-8"));
+    expect(content).toHaveProperty(
+      "dynamicRootValue",
+      "This should be wrapped in an object",
+    );
+
+    // Clean up
+    fs.unlinkSync(outputPath);
+  });
+
   test("function-based stats work correctly", async () => {
     const service = new PlayerLanguageService();
 

--- a/language/metrics-output-plugin/src/__tests__/metrics-output-plugin.test.ts
+++ b/language/metrics-output-plugin/src/__tests__/metrics-output-plugin.test.ts
@@ -403,44 +403,6 @@ describe("WriteMetricsPlugin", () => {
     fs.unlinkSync(outputPath);
   });
 
-  test("function-based rootProperties that returns a non-object", async () => {
-    const service = new PlayerLanguageService();
-
-    service.addLSPPlugin(
-      new MetricsOutput({
-        outputDir: TEST_DIR,
-        fileName: "non_object",
-        rootProperties: () => "This should be wrapped in an object",
-      }),
-    );
-
-    await service.setAssetTypesFromModule([
-      Types,
-      ReferenceAssetsWebPluginManifest,
-    ]);
-
-    const document = TextDocument.create(
-      "non/object/test.json",
-      "json",
-      1,
-      JSON.stringify({ id: "test" }),
-    );
-
-    await service.validateTextDocument(document);
-
-    const outputPath = path.join(TEST_DIR, "non_object.json");
-    expect(fs.existsSync(outputPath)).toBe(true);
-
-    const content = JSON.parse(fs.readFileSync(outputPath, "utf-8"));
-    expect(content).toHaveProperty(
-      "dynamicRootValue",
-      "This should be wrapped in an object",
-    );
-
-    // Clean up
-    fs.unlinkSync(outputPath);
-  });
-
   test("function-based stats work correctly", async () => {
     const service = new PlayerLanguageService();
 

--- a/language/metrics-output-plugin/src/metrics-output.ts
+++ b/language/metrics-output-plugin/src/metrics-output.ts
@@ -264,14 +264,18 @@ export class MetricsOutput implements PlayerLanguageServicePlugin {
     // Evaluate root properties with current diagnostics and context
     const rootProps = this.evaluateRootProperties(diagnostics, documentContext);
 
-    // Apply root properties to the aggregated results using deep merge
+    // Deep merge root properties into aggregated results (preserve existing, extend new)
     this.aggregatedResults = deepMerge(this.aggregatedResults, rootProps);
 
-    // Write the aggregated results to a file
+    // Write ordered output: all root properties first, then content last
     const outputFilePath = path.join(fullOutputDir, `${this.fileName}.json`);
+    const { content, ...root } = this.aggregatedResults as {
+      content: Record<string, unknown>;
+      [k: string]: unknown;
+    };
     fs.writeFileSync(
       outputFilePath,
-      JSON.stringify(this.aggregatedResults, null, 2),
+      JSON.stringify({ ...root, content }, null, 2),
       "utf-8",
     );
 

--- a/language/metrics-output-plugin/src/metrics-output.ts
+++ b/language/metrics-output-plugin/src/metrics-output.ts
@@ -207,17 +207,13 @@ export class MetricsOutput implements PlayerLanguageServicePlugin {
   private generateFeatures(
     diagnostics: Diagnostic[],
     documentContext: DocumentContext,
-  ): Record<string, unknown> {
+  ): Record<string, any> {
     // If features is a function, evaluate it directly
     if (typeof this.features === "function") {
       try {
         const result = this.features(diagnostics, documentContext);
-        if (
-          typeof result === "object" &&
-          result !== null &&
-          !Array.isArray(result)
-        ) {
-          return result as Record<string, unknown>;
+        if (typeof result === "object" && result !== null) {
+          return result;
         }
         return { dynamicFeaturesValue: result };
       } catch (error) {

--- a/language/metrics-output-plugin/src/types.ts
+++ b/language/metrics-output-plugin/src/types.ts
@@ -1,0 +1,21 @@
+export type MetricFunction = (...args: any[]) => any;
+
+export type MetricValue =
+  | Record<string, unknown>
+  | number
+  | string
+  | boolean
+  | MetricFunction;
+
+export type MetricsRoot = Record<string, MetricValue> | MetricFunction;
+export type MetricsStats = Record<string, MetricValue> | MetricFunction;
+export type MetricsFeatures = Record<string, MetricValue> | MetricFunction;
+
+export type MetricsContent = {
+  stats: MetricsStats;
+  features?: MetricsFeatures;
+};
+
+export type MetricsReport = MetricsRoot & {
+  content: Record<string, MetricsContent>;
+};

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "tapable-ts": "^0.2.4",
     "timm": "^1.7.1",
     "tiny-uid": "^1.1.2",
+    "ts-deepmerge": "^7.0.2",
     "ts-loader": "^5.3.3",
     "ts-node": "^10.4.0",
     "tsconfig-to-swcconfig": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,7 +191,7 @@ importers:
         version: 10.46.0(@types/node@18.19.34)(typescript@5.5.4)
       babel-loader:
         specifier: ^8.2.5
-        version: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0(webpack-cli@3.3.12))
+        version: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0)
       bundle-analyzer:
         specifier: ^0.0.6
         version: 0.0.6
@@ -221,7 +221,7 @@ importers:
         version: 3.1.8
       css-loader:
         specifier: ^3.6.0
-        version: 3.6.0(webpack@4.47.0(webpack-cli@3.3.12))
+        version: 3.6.0(webpack@4.47.0)
       dequal:
         specifier: ^2.0.2
         version: 2.0.3
@@ -326,7 +326,7 @@ importers:
         version: 1.0.4
       modify-source-webpack-plugin:
         specifier: ^4.1.0
-        version: 4.1.0(webpack@4.47.0(webpack-cli@3.3.12))
+        version: 4.1.0(webpack@4.47.0)
       oclif:
         specifier: ^4.4.2
         version: 4.13.6
@@ -398,7 +398,7 @@ importers:
         version: 1.0.1
       style-loader:
         specifier: ^1.3.0
-        version: 1.3.0(webpack@4.47.0(webpack-cli@3.3.12))
+        version: 1.3.0(webpack@4.47.0)
       tapable-ts:
         specifier: ^0.2.4
         version: 0.2.4
@@ -408,6 +408,9 @@ importers:
       tiny-uid:
         specifier: ^1.1.2
         version: 1.1.2
+      ts-deepmerge:
+        specifier: ^7.0.2
+        version: 7.0.3
       ts-loader:
         specifier: ^5.3.3
         version: 5.4.5(typescript@5.5.4)
@@ -7715,6 +7718,7 @@ packages:
 
   metro-react-native-babel-preset@0.70.4:
     resolution: {integrity: sha512-qcJuLqvjlKhrOOuQShhVzCjjp7kHZIXCL+ybnYBqOY2ALVCyR3aELH0aUtOztRpJYFnqAMDOJmGqNVi6cUd24g==, tarball: https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.4.tgz}
+    deprecated: Use @react-native/babel-preset instead
     peerDependencies:
       '@babel/core': '*'
 
@@ -9777,6 +9781,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==, tarball: https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==, tarball: https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz}
@@ -10231,6 +10236,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-deepmerge@7.0.3:
+    resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==, tarball: https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.3.tgz}
+    engines: {node: '>=14.13.1'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==, tarball: https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz}
@@ -11274,8 +11283,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -11324,8 +11333,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.587.0
@@ -11382,11 +11391,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.596.0':
+  '@aws-sdk/client-sso-oidc@3.596.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -11425,6 +11434,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.592.0':
@@ -11470,11 +11480,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)':
+  '@aws-sdk/client-sts@3.596.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -11513,7 +11523,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.592.0':
@@ -11547,7 +11556,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/credential-provider-env': 3.587.0
       '@aws-sdk/credential-provider-http': 3.596.0
       '@aws-sdk/credential-provider-process': 3.587.0
@@ -11605,7 +11614,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.587.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.1
       '@smithy/types': 3.1.0
@@ -11721,7 +11730,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.587.0(@aws-sdk/client-sso-oidc@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.1
       '@smithy/shared-ini-file-loader': 3.1.1
@@ -16867,7 +16876,7 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
 
-  babel-loader@8.3.0(@babel/core@7.24.7)(webpack@4.47.0(webpack-cli@3.3.12)):
+  babel-loader@8.3.0(@babel/core@7.24.7)(webpack@4.47.0):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 3.3.2
@@ -17802,7 +17811,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  css-loader@3.6.0(webpack@4.47.0(webpack-cli@3.3.12)):
+  css-loader@3.6.0(webpack@4.47.0):
     dependencies:
       camelcase: 5.3.1
       cssesc: 3.0.0
@@ -21194,7 +21203,7 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  modify-source-webpack-plugin@4.1.0(webpack@4.47.0(webpack-cli@3.3.12)):
+  modify-source-webpack-plugin@4.1.0(webpack@4.47.0):
     dependencies:
       loader-utils-webpack-v4: loader-utils@2.0.4
       schema-utils: 4.2.0
@@ -23675,7 +23684,7 @@ snapshots:
 
   strnum@1.0.5: {}
 
-  style-loader@1.3.0(webpack@4.47.0(webpack-cli@3.3.12)):
+  style-loader@1.3.0(webpack@4.47.0):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.1
@@ -23812,7 +23821,7 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@1.4.5(webpack@4.47.0(webpack-cli@3.3.12)):
+  terser-webpack-plugin@1.4.5(webpack@4.47.0):
     dependencies:
       cacache: 12.0.4
       find-cache-dir: 2.1.0
@@ -23961,6 +23970,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
+
+  ts-deepmerge@7.0.3: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -24538,7 +24549,7 @@ snapshots:
       node-libs-browser: 2.2.1
       schema-utils: 1.0.0
       tapable: 1.1.3
-      terser-webpack-plugin: 1.4.5(webpack@4.47.0(webpack-cli@3.3.12))
+      terser-webpack-plugin: 1.4.5(webpack@4.47.0)
       watchpack: 1.7.5
       webpack-sources: 1.4.3
     optionalDependencies:


### PR DESCRIPTION
### Change Type (required)

- [ ] `patch`
- [ ] `minor`
- [ ] `major`

# Release Notes

Updating metrics output plugin so that the output file correctly updates and aggregates data if there are multiple times that validation occurs. This uses ts-deepmerge to ensure nested objects are merged correctly, and also groups all rootProperties before content.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.12.1--canary.222.5311</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.12.1--canary.222.5311
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
