### PR TITLE
[devtools] deep clone cached flow to avoid causing errors

### DIFF
--- a/devtools/plugins/desktop/basic/src/index.tsx
+++ b/devtools/plugins/desktop/basic/src/index.tsx
@@ -78,7 +78,7 @@ export class BasicWevDevtoolsPlugin implements ReactPlayerPlugin {
 
     // Flow
     player.hooks.onStart.tap(this.name, (f) => {
-      this.flow = f;
+      this.flow = structuredClone(f);
     });
 
     // View


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

With the `ManagedPlayer` paradigm, [`FlowManager.next`](https://github.com/player-ui/player/blob/373994c2cc9d4ada94af2e1fb9d7558a0c6825b9/react/player/src/manager/types.ts#L19-L28) accepts a [`CompletedState`](https://github.com/player-ui/player/blob/373994c2cc9d4ada94af2e1fb9d7558a0c6825b9/core/player/src/types.ts#L120-L129) providing access to the [`endState`](https://github.com/player-ui/player/blob/373994c2cc9d4ada94af2e1fb9d7558a0c6825b9/core/types/src/index.ts#L239-L240) — this `endState` is provided via content, represented as part of the [`Flow`](https://github.com/player-ui/player/blob/373994c2cc9d4ada94af2e1fb9d7558a0c6825b9/core/types/src/index.ts#L447-L471). There are use cases where some data contained within `endState` is used to retrieve the next Player content, such data might be required to be mutated before usable.

It may not be _best_ practice for consumers to take the `endState` object and mutate on it during this process, but it is what's happening today. Unfortunately, with Player UI Devtools enabled, an error is thrown when attempting to mutate. We can encourage folks to treat Player constructs as unwritable objects, **but Devtools should ideally be a silent observer, unable to cause errors outside the scope of Devtools**.

This is caused by storing the entire `Flow` instance within the [`immer`](https://immerjs.github.io/immer/)-managed devtools state, ultimately causing that instance to no longer be writeable, resulting in the following error:
```
TypeError: Cannot assign to read only property 'xxxxxxxx' of object '#<Object>
```

Upon closer inspection of the Flow instance, we can see it is indeed `unwritable`:
```js
> Object.getOwnPropertyDescriptor(flow, 'xxxxxxxx')
{ value: true, writable: false, enumerable: true, configurable: false }
```

Thus, the simple fix here for devtools, is to deep clone the `Flow` for use within devtools.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

# Release Notes

Fix issue where storing the `Flow` instance within Player UI Devtools state caused errors when consumers attempted to mutating the instance, even _after_ the Player has completed.