### PR TITLE
feat: add hook to support skipCompilation for dsl compilation

### DIFF
--- a/cli/src/commands/dsl/compile.ts
+++ b/cli/src/commands/dsl/compile.ts
@@ -66,7 +66,6 @@ export default class DSLCompile extends BaseCommand {
       exp,
       severity: flags.severity,
       loglevel: flags.loglevel,
-      skipFiles: config.dsl?.skipFiles || [],
     };
   }
 
@@ -74,7 +73,7 @@ export default class DSLCompile extends BaseCommand {
     /** the status code */
     exitCode: number;
   }> {
-    const { input, output, skipValidation, exp, severity, loglevel, skipFiles } =
+    const { input, output, skipValidation, exp, severity, loglevel } =
       await this.getOptions();
 
     const files = await glob(
@@ -102,14 +101,10 @@ export default class DSLCompile extends BaseCommand {
     const compileFile = async (
       file: string,
     ): Promise<CompilationResult | undefined> => {
-      // Check if compilation should be skipped for this file
-      const fileName = path.basename(file);
-      const shouldSkipByConfig = skipFiles.includes(fileName);
-      
       // Check if any plugin wants to skip this file
-      const shouldSkipByPlugin = await context.hooks.skipCompilation.call(file);
+      const shouldSkipCompilation = await context.hooks.skipCompilation.call(file);
       
-      if (shouldSkipByConfig || shouldSkipByPlugin) {
+      if (shouldSkipCompilation) {
         this.log(
           `${logSymbols.info} Skipping compilation for %s`,
           normalizePath(file),

--- a/cli/src/commands/dsl/compile.ts
+++ b/cli/src/commands/dsl/compile.ts
@@ -101,6 +101,17 @@ export default class DSLCompile extends BaseCommand {
     const compileFile = async (
       file: string,
     ): Promise<CompilationResult | undefined> => {
+      
+      // Check if compilation should be skipped for this file
+      const shouldSkip = await context.hooks.skipCompilation.call(file);
+      if (shouldSkip) {
+        this.log(
+          `${logSymbols.info} Skipping compilation for %s`,
+          normalizePath(file),
+        );
+        return;
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const requiredModule = require(path.resolve(file));
       const defaultExport = requiredModule.default;

--- a/cli/src/commands/dsl/compile.ts
+++ b/cli/src/commands/dsl/compile.ts
@@ -101,7 +101,6 @@ export default class DSLCompile extends BaseCommand {
     const compileFile = async (
       file: string,
     ): Promise<CompilationResult | undefined> => {
-      
       // Check if compilation should be skipped for this file
       const shouldSkip = await context.hooks.skipCompilation.call(file);
       if (shouldSkip) {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -22,6 +22,9 @@ export interface PlayerConfigResolvedShape {
 
     /** Flag to omit validating the resulting JSON */
     skipValidation?: boolean;
+
+    /** Array of file paths to skip during compilation */
+    skipFiles?: string[];
   };
 
   /** Options related to JSON and validation */

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -22,9 +22,6 @@ export interface PlayerConfigResolvedShape {
 
     /** Flag to omit validating the resulting JSON */
     skipValidation?: boolean;
-
-  /** Array of file names to skip during compilation */
-   skipFiles?: string[];
   };
 
   /** Options related to JSON and validation */

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -23,8 +23,8 @@ export interface PlayerConfigResolvedShape {
     /** Flag to omit validating the resulting JSON */
     skipValidation?: boolean;
 
-    /** Array of file paths to skip during compilation */
-    skipFiles?: string[];
+  /** Array of file names to skip during compilation */
+   skipFiles?: string[];
   };
 
   /** Options related to JSON and validation */

--- a/cli/src/utils/compilation-context.ts
+++ b/cli/src/utils/compilation-context.ts
@@ -51,6 +51,17 @@ export class CompilationContext {
       [compileContentArgs, any, string],
       compilationResult
     >(),
+
+    /**
+     * Function for determining if a file should be skipped during compilation
+     *
+     * @param fileName - The relative name of the file
+     * @returns true if the file should be skipped, false or undefined otherwise
+     */
+    skipCompilation: new AsyncSeriesBailHook<
+      [string],
+      boolean
+    >(),
   };
 
   /** A DSL compiler instance */

--- a/cli/src/utils/compilation-context.ts
+++ b/cli/src/utils/compilation-context.ts
@@ -58,10 +58,7 @@ export class CompilationContext {
      * @param fileName - The relative name of the file
      * @returns true if the file should be skipped, false or undefined otherwise
      */
-    skipCompilation: new AsyncSeriesBailHook<
-      [string],
-      boolean
-    >(),
+    skipCompilation: new AsyncSeriesBailHook<[string], boolean>(),
   };
 
   /** A DSL compiler instance */


### PR DESCRIPTION
## Description
- Adds a new hook to `CompilationContext` to allow plugins to indicate files that should skip the dsl compilation step
## Changes
- Added `skipCompilation` hook to `CompilationContext` to determine if a file should be skipped during compilation
- Added a check in `compileFile` to skip compilation if hook returns true

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`

# Release Notes
 - Add a new hook `skipCompilation` for `player dsl compile`, allowing plugins to indicate files to skip dsl compilation step
<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->